### PR TITLE
Making cancelPageSwipe configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ as well as the absolute delta of where the swipe started and where it's currentl
 
 `delta` is the amount of px before we start firing events. The default value is 10.
 
+`cancelPageSwipe` should the `preventDefault()` function be called appon each swipe. Default is true.
+
     onFlick: React.PropTypes.func,
     onSwiped: React.PropTypes.func,
     onSwipingUp: React.PropTypes.func,
@@ -44,7 +46,8 @@ as well as the absolute delta of where the swipe started and where it's currentl
     onSwipingDown: React.PropTypes.func,
     onSwipingLeft: React.PropTypes.func,
     flickThreshold: React.PropTypes.number,
-    delta: React.PropTypes.number
+    delta: React.PropTypes.number,
+    cancelPageSwipe: React.PropTypes.bool
 
 # License
 

--- a/Swipeable.js
+++ b/Swipeable.js
@@ -9,7 +9,8 @@ var Swipeable = React.createClass({
     onSwipingDown: React.PropTypes.func,
     onSwipingLeft: React.PropTypes.func,
     flickThreshold: React.PropTypes.number,
-    delta: React.PropTypes.number
+    delta: React.PropTypes.number,
+    cancelPageSwipe: React.PropTypes.bool
   },
 
   getInitialState: function () {
@@ -24,7 +25,8 @@ var Swipeable = React.createClass({
   getDefaultProps: function () {
     return {
       flickThreshold: 0.6,
-      delta: 10
+      delta: 10,
+      cancelPageSwipe: true
     }
   },
 
@@ -98,7 +100,7 @@ var Swipeable = React.createClass({
 
     this.setState({ swiping: true })
 
-    if (cancelPageSwipe) {
+    if (cancelPageSwipe && this.props.cancelPageSwipe) {
       e.preventDefault()
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Swipe bindings for react",
   "main": "Swipeable.js",
   "scripts": {


### PR DESCRIPTION
In the single page apps built with cordova/phonegap this is unnecessary and it's causing warnings about preventing uncancellable events in Chrome emulator.