### PR TITLE
Fix horizontal swipe end event

### DIFF
--- a/js/Swipeable.js
+++ b/js/Swipeable.js
@@ -1,6 +1,8 @@
 var React = require('react')
+var assign = require('object-assign')
+var wasSwipingHorizontally = false
 
-var Swipeable = React.createClass({displayName: "Swipeable",
+var Swipeable = React.createClass({
   propTypes: {
     onSwiped: React.PropTypes.func,
     onSwipingUp: React.PropTypes.func,
@@ -78,15 +80,17 @@ var Swipeable = React.createClass({displayName: "Swipeable",
         if (this.props.onSwipingLeft) {
           this.props.onSwipingLeft(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
         }
       } else {
         if (this.props.onSwipingRight) {
           this.props.onSwipingRight(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
         }
       }
     } else {
-      if (pos.deltaY > 0) {
+      if (pos.deltaY < 0) {
         if (this.props.onSwipingUp) {
           this.props.onSwipingUp(e, pos.absY)
           cancelPageSwipe = true
@@ -120,34 +124,33 @@ var Swipeable = React.createClass({displayName: "Swipeable",
         pos.deltaY,
         isFlick
       )
-      
-      if (pos.absX > pos.absY) {
+
+      if (pos.absX > pos.absY || this.wasSwipingHorizontally) {
         if (pos.deltaX > 0) {
-          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX, isFlick)
+          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX)
+          this.wasSwipingHorizontally = false
         } else {
-          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX, isFlick)
+          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX)
+          this.wasSwipingHorizontally = false
         }
       } else {
-        if (pos.deltaY > 0) {
-          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY, isFlick)
+        if (pos.deltaY < 0) {
+          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY)
         } else {
-          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY, isFlick)
+          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY)
         }
       }
     }
-    
+
     this.setState(this.getInitialState())
   },
 
   render: function () {
-    return (
-      React.createElement("div", React.__spread({},  this.props, 
-        {onTouchStart: this.touchStart, 
-        onTouchMove: this.touchMove, 
-        onTouchEnd: this.touchEnd}), 
-          this.props.children
-      )  
-    )
+    return React.createElement('div', assign({
+      onTouchStart: this.touchStart,
+      onTouchMove: this.touchMove,
+      onTouchEnd: this.touchEnd
+    }, this.props), this.props.children)
   }
 })
 

--- a/js/Swipeable.js
+++ b/js/Swipeable.js
@@ -1,5 +1,4 @@
 var React = require('react')
-var assign = require('object-assign')
 var wasSwipingHorizontally = false
 
 var Swipeable = React.createClass({
@@ -90,7 +89,7 @@ var Swipeable = React.createClass({
         }
       }
     } else {
-      if (pos.deltaY < 0) {
+      if (pos.deltaY > 0) {
         if (this.props.onSwipingUp) {
           this.props.onSwipingUp(e, pos.absY)
           cancelPageSwipe = true
@@ -127,17 +126,17 @@ var Swipeable = React.createClass({
 
       if (pos.absX > pos.absY || this.wasSwipingHorizontally) {
         if (pos.deltaX > 0) {
-          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX)
+          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX, isFlick)
           this.wasSwipingHorizontally = false
         } else {
-          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX)
+          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX, isFlick)
           this.wasSwipingHorizontally = false
         }
       } else {
-        if (pos.deltaY < 0) {
-          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY)
+        if (pos.deltaY > 0) {
+          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY, isFlick)
         } else {
-          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY)
+          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY, isFlick)
         }
       }
     }
@@ -146,11 +145,14 @@ var Swipeable = React.createClass({
   },
 
   render: function () {
-    return React.createElement('div', assign({
-      onTouchStart: this.touchStart,
-      onTouchMove: this.touchMove,
-      onTouchEnd: this.touchEnd
-    }, this.props), this.props.children)
+    return (
+      <div {...this.props}
+        onTouchStart={this.touchStart}
+        onTouchMove={this.touchMove}
+        onTouchEnd={this.touchEnd} >
+          {this.props.children}
+      </div>
+    )
   }
 })
 

--- a/js/Swipeable.js
+++ b/js/Swipeable.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var wasSwipingHorizontally = false
 
-var Swipeable = React.createClass({
+var Swipeable = React.createClass({displayName: "Swipeable",
   propTypes: {
     onSwiped: React.PropTypes.func,
     onSwipingUp: React.PropTypes.func,

--- a/js/Swipeable.js
+++ b/js/Swipeable.js
@@ -145,15 +145,15 @@ var Swipeable = React.createClass({displayName: "Swipeable",
   },
 
   render: function () {
-    return (
-      <div {...this.props}
-        onTouchStart={this.touchStart}
-        onTouchMove={this.touchMove}
-        onTouchEnd={this.touchEnd} >
-          {this.props.children}
-      </div>
-    )
-  }
+      return (
+        React.createElement("div", React.__spread({},  this.props,
+          {onTouchStart: this.touchStart,
+          onTouchMove: this.touchMove,
+          onTouchEnd: this.touchEnd}),
+            this.props.children
+        )
+      )
+    }
 })
 
 module.exports = Swipeable

--- a/jsx/Swipeable.jsx
+++ b/jsx/Swipeable.jsx
@@ -1,4 +1,6 @@
 var React = require('react')
+var assign = require('object-assign')
+var wasSwipingHorizontally = false
 
 var Swipeable = React.createClass({
   propTypes: {
@@ -78,15 +80,17 @@ var Swipeable = React.createClass({
         if (this.props.onSwipingLeft) {
           this.props.onSwipingLeft(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
         }
       } else {
         if (this.props.onSwipingRight) {
           this.props.onSwipingRight(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
         }
       }
     } else {
-      if (pos.deltaY > 0) {
+      if (pos.deltaY < 0) {
         if (this.props.onSwipingUp) {
           this.props.onSwipingUp(e, pos.absY)
           cancelPageSwipe = true
@@ -120,34 +124,33 @@ var Swipeable = React.createClass({
         pos.deltaY,
         isFlick
       )
-      
-      if (pos.absX > pos.absY) {
+
+      if (pos.absX > pos.absY || this.wasSwipingHorizontally) {
         if (pos.deltaX > 0) {
-          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX, isFlick)
+          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX)
+          this.wasSwipingHorizontally = false
         } else {
-          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX, isFlick)
+          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX)
+          this.wasSwipingHorizontally = false
         }
       } else {
-        if (pos.deltaY > 0) {
-          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY, isFlick)
+        if (pos.deltaY < 0) {
+          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY)
         } else {
-          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY, isFlick)
+          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY)
         }
       }
     }
-    
+
     this.setState(this.getInitialState())
   },
 
   render: function () {
-    return (
-      <div {...this.props}
-        onTouchStart={this.touchStart}
-        onTouchMove={this.touchMove}
-        onTouchEnd={this.touchEnd} >
-          {this.props.children}
-      </div>  
-    )
+    return React.createElement('div', assign({
+      onTouchStart: this.touchStart,
+      onTouchMove: this.touchMove,
+      onTouchEnd: this.touchEnd
+    }, this.props), this.props.children)
   }
 })
 

--- a/jsx/Swipeable.jsx
+++ b/jsx/Swipeable.jsx
@@ -1,5 +1,4 @@
 var React = require('react')
-var assign = require('object-assign')
 var wasSwipingHorizontally = false
 
 var Swipeable = React.createClass({
@@ -90,7 +89,7 @@ var Swipeable = React.createClass({
         }
       }
     } else {
-      if (pos.deltaY < 0) {
+      if (pos.deltaY > 0) {
         if (this.props.onSwipingUp) {
           this.props.onSwipingUp(e, pos.absY)
           cancelPageSwipe = true
@@ -127,17 +126,17 @@ var Swipeable = React.createClass({
 
       if (pos.absX > pos.absY || this.wasSwipingHorizontally) {
         if (pos.deltaX > 0) {
-          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX)
+          this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX, isFlick)
           this.wasSwipingHorizontally = false
         } else {
-          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX)
+          this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX, isFlick)
           this.wasSwipingHorizontally = false
         }
       } else {
-        if (pos.deltaY < 0) {
-          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY)
+        if (pos.deltaY > 0) {
+          this.props.onSwipedUp && this.props.onSwipedUp(ev, pos.deltaY, isFlick)
         } else {
-          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY)
+          this.props.onSwipedDown && this.props.onSwipedDown(ev, pos.deltaY, isFlick)
         }
       }
     }
@@ -146,11 +145,14 @@ var Swipeable = React.createClass({
   },
 
   render: function () {
-    return React.createElement('div', assign({
-      onTouchStart: this.touchStart,
-      onTouchMove: this.touchMove,
-      onTouchEnd: this.touchEnd
-    }, this.props), this.props.children)
+    return (
+      <div {...this.props}
+        onTouchStart={this.touchStart}
+        onTouchMove={this.touchMove}
+        onTouchEnd={this.touchEnd} >
+          {this.props.children}
+      </div>
+    )
   }
 })
 

--- a/jsx/Swipeable.jsx
+++ b/jsx/Swipeable.jsx
@@ -1,7 +1,7 @@
 var React = require('react')
 var wasSwipingHorizontally = false
 
-var Swipeable = React.createClass({
+var Swipeable = React.createClass({displayName: "Swipeable",
   propTypes: {
     onSwiped: React.PropTypes.func,
     onSwipingUp: React.PropTypes.func,


### PR DESCRIPTION
Events onSwipedLeft & onSwipedRight were sometimes NOT firing incorrectly. If the swipe ended in the same positions as it started, (i.e. absX = 0), the first check would fail and would go to the "else" statement which fired onSwipedUp or onSwipedDown