### PR TITLE
Fixing problem with horizontal swiped events

### DIFF
--- a/js/Swipeable.js
+++ b/js/Swipeable.js
@@ -1,4 +1,5 @@
 var React = require('react')
+var wasSwipingHorizontally = false
 
 var Swipeable = React.createClass({displayName: "Swipeable",
   propTypes: {
@@ -78,11 +79,13 @@ var Swipeable = React.createClass({displayName: "Swipeable",
         if (this.props.onSwipingLeft) {
           this.props.onSwipingLeft(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
         }
       } else {
         if (this.props.onSwipingRight) {
           this.props.onSwipingRight(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
         }
       }
     } else {
@@ -120,12 +123,14 @@ var Swipeable = React.createClass({displayName: "Swipeable",
         pos.deltaY,
         isFlick
       )
-      
-      if (pos.absX > pos.absY) {
+
+      if (pos.absX > pos.absY || this.wasSwipingHorizontally) {
         if (pos.deltaX > 0) {
           this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX, isFlick)
+          this.wasSwipingHorizontally = false
         } else {
           this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX, isFlick)
+          this.wasSwipingHorizontally = false
         }
       } else {
         if (pos.deltaY > 0) {
@@ -135,18 +140,18 @@ var Swipeable = React.createClass({displayName: "Swipeable",
         }
       }
     }
-    
+
     this.setState(this.getInitialState())
   },
 
   render: function () {
     return (
-      React.createElement("div", React.__spread({},  this.props, 
-        {onTouchStart: this.touchStart, 
-        onTouchMove: this.touchMove, 
-        onTouchEnd: this.touchEnd}), 
+      React.createElement("div", React.__spread({},  this.props,
+        {onTouchStart: this.touchStart,
+        onTouchMove: this.touchMove,
+        onTouchEnd: this.touchEnd}),
           this.props.children
-      )  
+      )
     )
   }
 })

--- a/jsx/Swipeable.jsx
+++ b/jsx/Swipeable.jsx
@@ -1,4 +1,5 @@
 var React = require('react')
+var wasSwipingHorizontally = false
 
 var Swipeable = React.createClass({
   propTypes: {
@@ -78,11 +79,15 @@ var Swipeable = React.createClass({
         if (this.props.onSwipingLeft) {
           this.props.onSwipingLeft(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
+
         }
       } else {
         if (this.props.onSwipingRight) {
           this.props.onSwipingRight(e, pos.absX)
           cancelPageSwipe = true
+          this.wasSwipingHorizontally = true
+
         }
       }
     } else {
@@ -120,12 +125,14 @@ var Swipeable = React.createClass({
         pos.deltaY,
         isFlick
       )
-      
-      if (pos.absX > pos.absY) {
+
+      if (pos.absX > pos.absY || this.wasSwipingHorizontally) {
         if (pos.deltaX > 0) {
           this.props.onSwipedLeft && this.props.onSwipedLeft(ev, pos.deltaX, isFlick)
+          this.wasSwipingHorizontally = false
         } else {
           this.props.onSwipedRight && this.props.onSwipedRight(ev, pos.deltaX, isFlick)
+          this.wasSwipingHorizontally = false
         }
       } else {
         if (pos.deltaY > 0) {
@@ -135,7 +142,7 @@ var Swipeable = React.createClass({
         }
       }
     }
-    
+
     this.setState(this.getInitialState())
   },
 
@@ -146,7 +153,7 @@ var Swipeable = React.createClass({
         onTouchMove={this.touchMove}
         onTouchEnd={this.touchEnd} >
           {this.props.children}
-      </div>  
+      </div>
     )
   }
 })


### PR DESCRIPTION
If a horizontal swipe ended up where it started, the if check would fail and the onSwipedLeft and onSwipedRight events would not fire. Fixed by adding an extra check for a flag that was enabled during horizontal scrolling