### PR TITLE
Make preventing the default touch event optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var SampleComponent = React.createClass({
         onSwipedDown={this.swipedDown}
         onSwipedLeft={this.swipedLeft}
         onSwiped={this.handleSwipeAction}
-        preventDefaultTouchMoveEvent={false}>
+        preventDefaultTouchmoveEvent={false}>
         <div>
           This element can be swiped
         </div>
@@ -53,7 +53,7 @@ as well as the x distance, + or -, from where the swipe started to where it ende
 
 `delta` is the amount of px before we start firing events. Also effects how far `onSwipedUp`, `onSwipedRight`, `onSwipedDown`, and `onSwipedLeft` need to be before they fire events. The default value is 10.
 
-`preventDefaultTouchMoveEvent` is whether to prevent the browser's `[touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove)` event.  Sometimes you would like the target to scroll natively.  The default value is `true`.
+`preventDefaultTouchmoveEvent` is whether to prevent the browser's `[touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove)` event.  Sometimes you would like the target to scroll natively.  The default value is `true`.
 
 ### PropTypes
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ var SampleComponent = React.createClass({
         onSwipedRight={this.swipedRight}
         onSwipedDown={this.swipedDown}
         onSwipedLeft={this.swipedLeft}
-        onSwiped={this.handleSwipeAction}>
+        onSwiped={this.handleSwipeAction}
+        preventDefaultTouchMoveEvent={false}>
         <div>
           This element can be swiped
         </div>
@@ -52,6 +53,8 @@ as well as the x distance, + or -, from where the swipe started to where it ende
 
 `delta` is the amount of px before we start firing events. Also effects how far `onSwipedUp`, `onSwipedRight`, `onSwipedDown`, and `onSwipedLeft` need to be before they fire events. The default value is 10.
 
+`preventDefaultTouchMoveEvent` is whether to prevent the browser's `[touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove)` event.  Sometimes you would like the target to scroll natively.  The default value is `true`.
+
 ### PropTypes
 
 ```
@@ -66,7 +69,8 @@ as well as the x distance, + or -, from where the swipe started to where it ende
   onSwipedDown: React.PropTypes.func,
   onSwipedLeft: React.PropTypes.func,
   flickThreshold: React.PropTypes.number,
-  delta: React.PropTypes.number
+  delta: React.PropTypes.number,
+  preventDefaultTouchmoveEvent: React.PropTypes.bool
 ```
 
 ## Development

--- a/examples/app/Main.js
+++ b/examples/app/Main.js
@@ -5,11 +5,12 @@ const initialState = {
   swiping: false,
   swiped: false,
   swipingDirection: '',
-  swipedDirection: '',
+  swipedDirection: ''
 };
 const initialStateSwipeable = {
   flickThreshold: '0.6',
   delta: '10',
+  preventDefaultTouchmoveEvent: true
 };
 
 export default class Main extends Component {
@@ -68,6 +69,7 @@ export default class Main extends Component {
       swipedDirection,
       flickThreshold,
       delta,
+      preventDefaultTouchmoveEvent
     } = this.state;
     const boundSwipes = getBoundSwipes(this);
     const isFlickThresholdNumber = !(isNaN(flickThreshold) || flickThreshold === '');
@@ -91,11 +93,14 @@ export default class Main extends Component {
                 onSwiping={(...args)=>this.onSwiping(...args)}
                 onSwiped={(...args)=>this.onSwiped(...args)}
                 flickThreshold={flickThresholdNum}
-                delta={deltaNum}>
+                delta={deltaNum}
+                preventDefaultTouchmoveEvent={preventDefaultTouchmoveEvent}>
                 <div className="callout"
                   onTouchStart={()=>this.resetState()}
-                  style={{height: '150px'}}>
+                  style={{height: '150px', overflowY: 'scroll'}}>
                   <h5>Swipe inside here...</h5>
+                  <p>Here is some filler to make it scrollable...</p>
+                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                 </div>
               </Swipeable>
             </div>
@@ -125,6 +130,15 @@ export default class Main extends Component {
                     <input type="text"
                       style={{margin: '0px', border: !isFlickThresholdNumber ? '2px solid red' : ''}}
                       onChange={(e)=>this.updateValue('flickThreshold', getVal(e))} value={flickThreshold}/>
+                  </td>
+                </tr>
+                <tr>
+                  <td>preventDefaultTouchmoveEvent:</td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={preventDefaultTouchmoveEvent}
+                      onChange={(e)=>this.updateValue('preventDefaultTouchmoveEvent', e.target.checked)}/>
                   </td>
                 </tr>
               </tbody>

--- a/js/Swipeable.js
+++ b/js/Swipeable.js
@@ -13,7 +13,8 @@ var Swipeable = React.createClass({displayName: "Swipeable",
     onSwipedDown: React.PropTypes.func,
     onSwipedLeft: React.PropTypes.func,
     flickThreshold: React.PropTypes.number,
-    delta: React.PropTypes.number
+    delta: React.PropTypes.number,
+    preventDefaultTouchmoveEvent: React.PropTypes.bool
   },
 
   getInitialState: function () {
@@ -28,7 +29,8 @@ var Swipeable = React.createClass({displayName: "Swipeable",
   getDefaultProps: function () {
     return {
       flickThreshold: 0.6,
-      delta: 10
+      delta: 10,
+      preventDefaultTouchmoveEvent: true
     }
   },
 
@@ -106,7 +108,7 @@ var Swipeable = React.createClass({displayName: "Swipeable",
 
     this.setState({ swiping: true })
 
-    if (cancelPageSwipe) {
+    if (cancelPageSwipe && this.props.preventDefaultTouchmoveEvent) {
       e.preventDefault()
     }
   },

--- a/jsx/Swipeable.jsx
+++ b/jsx/Swipeable.jsx
@@ -13,7 +13,8 @@ var Swipeable = React.createClass({
     onSwipedDown: React.PropTypes.func,
     onSwipedLeft: React.PropTypes.func,
     flickThreshold: React.PropTypes.number,
-    delta: React.PropTypes.number
+    delta: React.PropTypes.number,
+    preventDefaultTouchmoveEvent: React.PropTypes.bool
   },
 
   getInitialState: function () {
@@ -28,7 +29,8 @@ var Swipeable = React.createClass({
   getDefaultProps: function () {
     return {
       flickThreshold: 0.6,
-      delta: 10
+      delta: 10,
+      preventDefaultTouchmoveEvent: true
     }
   },
 
@@ -106,7 +108,7 @@ var Swipeable = React.createClass({
 
     this.setState({ swiping: true })
 
-    if (cancelPageSwipe) {
+    if (cancelPageSwipe && this.props.preventDefaultTouchmoveEvent) {
       e.preventDefault()
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Swipe bindings for react",
   "main": "js/Swipeable.js",
   "scripts": {


### PR DESCRIPTION
Adds a `preventDefaultTouchMoveEvent` prop to `Swipeable` that looks like this:

```
<Swipeable
    onSwiping={this.swiping}
    ...
    preventDefaultTouchMoveEvent={false}>
    <div>
        This element can be swiped
    </div>
</Swipeable>
```

The default is `true` to preserve default behaviour.

This PR supersedes PR https://github.com/dogfessional/react-swipeable/pull/1 and resolves https://github.com/dogfessional/react-swipeable/issues/28 and https://github.com/dogfessional/react-swipeable/issues/21 (as long as the option is passed).

- [x] readme updated
- [x] examples updated.  I think I did the right thing with `./scripts/build_gh_pages.sh`:  I committed changes in `./examples` to `master`, then ran `./scripts/build_gh_pages.sh` which appeared to do branching/building/commit type stuff.  If you like I can formalise this process in the readme as part of this PR.

Thanks.