### PR TITLE
fix for errors when adding all props to div

### DIFF
--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -162,7 +162,7 @@ const Swipeable = React.createClass({
 
   render: function () {
     const newProps = {
-      ...this.props,
+      style:this.props.style,
       onTouchStart: this.touchStart,
       onTouchMove: this.touchMove,
       onTouchEnd: this.touchEnd,


### PR DESCRIPTION
When switching to react 15 and babel 6 you get errors when adding all props to div, so have changed it to only push style into div