### PR TITLE
Not using React state for swipe state

### DIFF
--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -1,5 +1,14 @@
 const React = require('react')
 
+function getInitialState () {
+  return {
+    x: null,
+    y: null,
+    swiping: false,
+    start: 0
+  };
+}
+
 const Swipeable = React.createClass({
   propTypes: {
     onSwiped: React.PropTypes.func,
@@ -20,13 +29,8 @@ const Swipeable = React.createClass({
     trackMouse: React.PropTypes.bool
   },
 
-  getInitialState: function () {
-    return {
-      x: null,
-      y: null,
-      swiping: false,
-      start: 0
-    }
+  componentWillMount: function () {
+    this.swipeable = getInitialState();
   },
 
   getDefaultProps: function () {
@@ -50,13 +54,13 @@ const Swipeable = React.createClass({
         y = e.clientY
     }
 
-    const xd = this.state.x - x
-    const yd = this.state.y - y
+    const xd = this.swipeable.x - x
+    const yd = this.swipeable.y - y
 
     const axd = Math.abs(xd)
     const ayd = Math.abs(yd)
 
-    const time = Date.now() - this.state.start
+    const time = Date.now() - this.swipeable.start
     const velocity = Math.sqrt(axd * axd + ayd * ayd) / time
 
     return {
@@ -79,16 +83,16 @@ const Swipeable = React.createClass({
     }
     if (this.props.stopPropagation) e.stopPropagation()
 
-    this.setState({
+    this.swipeable = {
       start: Date.now(),
       x: touches[0].clientX,
       y: touches[0].clientY,
       swiping: false
-    })
+    };
   },
 
   eventMove: function (e) {
-    if (!this.state.x || !this.state.y || e.touches && e.touches.length > 1) {
+    if (!this.swipeable.x || !this.swipeable.y || e.touches && e.touches.length > 1) {
       return
     }
 
@@ -131,7 +135,7 @@ const Swipeable = React.createClass({
       }
     }
 
-    this.setState({ swiping: true })
+    this.swipeable.swiping = true;
 
     if (cancelPageSwipe && this.props.preventDefaultTouchmoveEvent) {
       e.preventDefault()
@@ -139,7 +143,7 @@ const Swipeable = React.createClass({
   },
 
   eventEnd: function (e) {
-    if (this.state.swiping) {
+    if (this.swipeable.swiping) {
       const pos = this.calculatePos(e)
 
       if (this.props.stopPropagation) e.stopPropagation()
@@ -169,7 +173,7 @@ const Swipeable = React.createClass({
       }
     }
 
-    this.setState(this.getInitialState())
+    this.swipeable = getInitialState();
   },
 
   render: function () {


### PR DESCRIPTION
The state used for `x`, `y`, `swiping` and `start` aren't used in the render methods (nothing is supposed to happen really, as it's up to the user of `react-swipeable` to perform any x/y-translations), and using setState() will trigger React logic to perform things which may cause stuttering and slow down transitions, etc.

This PR will save the state in a local variable `this.swipable` instead of the React state, to ensure we bypass all React state logic, since it's not needed.