### PR TITLE
add innerRef prop for ref element access

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ as well as the x distance, + or -, from where the swipe started to where it ende
 
 **`trackMouse`** will allow mouse 'swipes' to be tracked(click, hold, move, let go). See [#51](https://github.com/dogfessional/react-swipeable/issues/51) for more details. The default value is `false`.
 
+**`innerRef`** will allow access to the Swipeable's inner dom node element react ref. See [#81](https://github.com/dogfessional/react-swipeable/issues/81) for more details. Example usage `<Swipeable innerRef={(el) => this.swipeableEl = el} >`. Then you'll have access to the dom element that Swipeable uses internally.
+
 **None of the props are required.**
 ### PropType Definitions
 
@@ -94,6 +96,7 @@ as well as the x distance, + or -, from where the swipe started to where it ende
   stopPropagation: PropTypes.bool, // default: false
   nodeName: PropTypes.string // default: div
   trackMouse: PropTypes.bool, // default: false
+  innerRef: PropTypes.func,
 ```
 
 ### Chrome 56 and later, warning with preventDefault

--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -200,6 +200,9 @@ class Swipeable extends React.Component {
       onTouchEnd: this.eventEnd,
       onMouseDown: this.mouseDown,
     };
+    if (this.props.innerRef) {
+      newProps.ref = this.props.innerRef;
+    }
 
     // clean up swipeable's props to avoid react warning
     delete newProps.onSwiped;
@@ -220,6 +223,7 @@ class Swipeable extends React.Component {
     delete newProps.nodeName;
     delete newProps.children;
     delete newProps.trackMouse;
+    delete newProps.innerRef;
 
     return React.createElement(
       this.props.nodeName,
@@ -247,6 +251,7 @@ Swipeable.propTypes = {
   stopPropagation: PropTypes.bool,
   nodeName: PropTypes.string,
   trackMouse: PropTypes.bool,
+  innerRef: PropTypes.func,
   children: PropTypes.node,
 };
 

--- a/src/__tests__/Swipeable.spec.js
+++ b/src/__tests__/Swipeable.spec.js
@@ -228,4 +228,15 @@ describe('Swipeable', () => {
     expect(onSwipedLeft).toHaveBeenCalledTimes(1);
     expect(onSwipedRight).not.toHaveBeenCalled();
   });
+
+  it('should pass ref to the component via innerRef prop', () => {
+    const WrapperComp = class extends React.Component {
+      render() {
+        return <Swipeable innerRef={el => this.testRef = el} /> // eslint-disable-line
+      }
+    };
+    const wrapper = mount((<WrapperComp />));
+    const swipeableDiv = wrapper.find('div').getNode();
+    expect(wrapper.node.testRef).toBe(swipeableDiv);
+  });
 });


### PR DESCRIPTION
adds `innerRef` prop

- [x] Allow users to access internal wrapping elements `ref` via a new prop called `innerRef`.

solves and will close #81 