### PR TITLE
Actually prevent passive touchmove events default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ as well as the x distance, + or -, from where the swipe started to where it ende
 
 **`delta`** is the amount of px before we start firing events. Also affects how far `onSwipedUp`, `onSwipedRight`, `onSwipedDown`, and `onSwipedLeft` need to be before they fire events. The default value is `10`.
 
-**`preventDefaultTouchmoveEvent`** is whether to prevent the browser's [touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove) event.  Sometimes you would like the target to scroll natively.  The default value is `false`. [Chrome 56 and later, warning with preventDefault](#chrome-56-and-later-warning-with-preventdefault)
+**`preventDefaultTouchmoveEvent`** is whether to prevent the browser's [touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove) event.  Sometimes you would like the target to scroll natively.  The default value is `false`.
  * **Notes** `e.preventDefault()` is only called when `preventDefaultTouchmoveEvent` is `true` **and** the user is swiping in a direction that has an associated directional `onSwiping` or `onSwiped` prop.
    * Example: user is swiping right with `<Swipable onSwipedRight={this.userSwipedRight} preventDefaultTouchmoveEvent={true} >` then `e.preventDefault()` will be called, but if user was swiping left `e.preventDefault()` would **not** be called.
    * Please experiment with [example](http://dogfessional.github.io/react-swipeable/) to test `preventDefaultTouchmoveEvent`.
@@ -111,20 +111,6 @@ as well as the x distance, + or -, from where the swipe started to where it ende
   disabled: PropTypes.bool, // default: false
   innerRef: PropTypes.func,
 ```
-
-### Chrome 56 and later, warning with preventDefault
-When this library tries to call `e.preventDefault()` in Chrome 56+ a warning is logged:
-`Unable to preventDefault inside passive event listener due to target being treated as passive.`
-
-This warning is because this [change](https://developers.google.com/web/updates/2017/01/scrolling-intervention) to Chrome 56+ and the way the synthetic events are setup in reactjs.
-
-If you'd like to prevent all scrolling/zooming within a `<Swipeable />` component you can pass a `touchAction` style property equal to `'none'`, [example](https://github.com/dogfessional/react-swipeable/blob/master/examples/app/Main.js#L143). Chrome's recommendation for  [reference](https://developers.google.com/web/updates/2017/01/scrolling-intervention).
-
-```
-<Swipeable style={{touchAction: 'none'}} />
-```
-
-Follow reacts handling of this issue here: [facebook/react#8968](https://github.com/facebook/react/issues/8968)
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
+    "detect-passive-events": "^1.0.4",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -51,6 +51,7 @@ class Swipeable extends React.Component {
     this.mouseUp = this.mouseUp.bind(this);
     this.cleanupMouseListeners = this.cleanupMouseListeners.bind(this);
     this.setupMouseListeners = this.setupMouseListeners.bind(this);
+    this.elementRef = this.elementRef.bind(this);
   }
 
   componentWillMount() {
@@ -214,33 +215,34 @@ class Swipeable extends React.Component {
     this.swipeable = getInitialState();
   }
 
+  elementRef(element) {
+    if (!element && DetectPassiveEvents.hasSupport) {
+      this.element.removeEventListener('touchmove', this.eventMove, { passive: false });
+    }
+
+    this.element = element;
+
+    if (element && this.props.preventDefaultTouchmoveEvent && DetectPassiveEvents.hasSupport) {
+      this.element.addEventListener('touchmove', this.eventMove, { passive: false });
+    }
+
+    if (this.props.innerRef) {
+      this.props.innerRef(element);
+    }
+  }
+
   render() {
-    const { disabled, innerRef } = this.props;
     const newProps = { ...this.props };
-    const nativeTouchMoveListener = newProps.preventDefaultTouchmoveEvent &&
-      DetectPassiveEvents.hasSupport;
-    if (!disabled) {
+    if (!this.props.disabled) {
       newProps.onTouchStart = this.eventStart;
-      if (!nativeTouchMoveListener) {
+      if (!newProps.preventDefaultTouchmoveEvent || !DetectPassiveEvents.hasSupport) {
         newProps.onTouchMove = this.eventMove;
       }
       newProps.onTouchEnd = this.eventEnd;
       newProps.onMouseDown = this.mouseDown;
     }
 
-    newProps.ref = (element) => {
-      if (!element && nativeTouchMoveListener) {
-        this.element.removeEventListener('touchmove', this.eventMove, { passive: false });
-      }
-
-      this.element = element;
-
-      if (element && nativeTouchMoveListener) {
-        this.element.addEventListener('touchmove', this.eventMove, { passive: false });
-      }
-
-      if (innerRef) innerRef(element);
-    };
+    newProps.ref = this.elementRef;
 
     // clean up swipeable's props to avoid react warning
     delete newProps.onSwiped;


### PR DESCRIPTION
It’s possible to listen to `touchmove` manually to ensure the listener has the ability to prevent the default event behavior. Otherwise it’s impossible to let users scroll vertically while playing a video with audio enabled on horizontal swipe in Chrome 56+. 