### PR TITLE
clean up componentWillMount

### DIFF
--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -43,6 +43,11 @@ function calculatePos(e, state) {
 class Swipeable extends React.Component {
   constructor(props, context) {
     super(props, context);
+    
+    // setup internal swipeable state
+    this.swipeable = getInitialState();
+    
+    // bind this context for internal methods
     this.eventStart = this.eventStart.bind(this);
     this.eventMove = this.eventMove.bind(this);
     this.eventEnd = this.eventEnd.bind(this);
@@ -54,12 +59,9 @@ class Swipeable extends React.Component {
     this.elementRef = this.elementRef.bind(this);
     this.setupTouchmoveEvent = this.setupTouchmoveEvent.bind(this);
     this.cleanupTouchmoveEvent = this.cleanupTouchmoveEvent.bind(this);
+    
+    // check for passive event support
     this.hasPassiveSupport = DetectPassiveEvents.hasSupport;
-  }
-
-  componentWillMount() {
-    // setup internal swipeable state
-    this.swipeable = getInitialState();
   }
 
   componentDidMount() {

--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -43,10 +43,10 @@ function calculatePos(e, state) {
 class Swipeable extends React.Component {
   constructor(props, context) {
     super(props, context);
-    
+
     // setup internal swipeable state
     this.swipeable = getInitialState();
-    
+
     // bind this context for internal methods
     this.eventStart = this.eventStart.bind(this);
     this.eventMove = this.eventMove.bind(this);
@@ -59,7 +59,7 @@ class Swipeable extends React.Component {
     this.elementRef = this.elementRef.bind(this);
     this.setupTouchmoveEvent = this.setupTouchmoveEvent.bind(this);
     this.cleanupTouchmoveEvent = this.cleanupTouchmoveEvent.bind(this);
-    
+
     // check for passive event support
     this.hasPassiveSupport = DetectPassiveEvents.hasSupport;
   }


### PR DESCRIPTION
Clean up `componentWillMount`. React is cleaning up problematic lifecycle methods, https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes

The "swipeable state" can just be set up in the constructor instead 😸 

closes #101 