### PR TITLE
clean up and simplify props

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,389 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Swipeable handles mouse events with trackMouse prop and fires correct props: Swipeable onSwiped trackMouse 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 100,
+      "absY": 0,
+      "deltaX": -100,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {},
+      "velocity": 1.5624999996816769,
+    },
+  ],
+]
+`;
+
+exports[`Swipeable handles mouse events with trackMouse prop and fires correct props: Swipeable onSwiping trackMouse 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 25,
+      "absY": 0,
+      "deltaX": -25,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 125,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374825.199999963,
+      },
+      "velocity": 1.592356689012699,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 50,
+      "absY": 0,
+      "deltaX": -50,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 150,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374841.3999999757,
+      },
+      "velocity": 1.5673981190353126,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 75,
+      "absY": 0,
+      "deltaX": -75,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 175,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374857.399999979,
+      },
+      "velocity": 1.565762004010972,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 100,
+      "absY": 0,
+      "deltaX": -100,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 200,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374873.499999987,
+      },
+      "velocity": 1.5624999996816769,
+    },
+  ],
+]
+`;
+
+exports[`Swipeable handles touch events and fires correct props: Swipeable onSwiped trackTouch 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 100,
+      "deltaX": 0,
+      "deltaY": -100,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "touches": Array [
+          Object {
+            "clientX": undefined,
+            "clientY": undefined,
+          },
+        ],
+      },
+      "velocity": 1.8903591679142773,
+    },
+  ],
+]
+`;
+
+exports[`Swipeable handles touch events and fires correct props: Swipeable onSwiping trackTouch 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 25,
+      "deltaX": 0,
+      "deltaY": -25,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8100.999999966007,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 125,
+          },
+        ],
+      },
+      "velocity": 1.0548523197963273,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 50,
+      "deltaX": 0,
+      "deltaY": -50,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8116.899999964517,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 150,
+          },
+        ],
+      },
+      "velocity": 1.2626262620442454,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 75,
+      "deltaX": 0,
+      "deltaY": -75,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8122.799999953713,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 175,
+          },
+        ],
+      },
+      "velocity": 1.6483516480817324,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 100,
+      "deltaX": 0,
+      "deltaY": -100,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8130.199999955433,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 200,
+          },
+        ],
+      },
+      "velocity": 1.8903591679142773,
+    },
+  ],
+]
+`;
+
+exports[`useSwipeable handles mouse events with trackMouse prop and fires correct props: useSwipeable onSwiped trackMouse 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 100,
+      "absY": 0,
+      "deltaX": -100,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {},
+      "velocity": 1.5624999996816769,
+    },
+  ],
+]
+`;
+
+exports[`useSwipeable handles mouse events with trackMouse prop and fires correct props: useSwipeable onSwiping trackMouse 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 25,
+      "absY": 0,
+      "deltaX": -25,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 125,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374825.199999963,
+      },
+      "velocity": 1.592356689012699,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 50,
+      "absY": 0,
+      "deltaX": -50,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 150,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374841.3999999757,
+      },
+      "velocity": 1.5673981190353126,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 75,
+      "absY": 0,
+      "deltaX": -75,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 175,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374857.399999979,
+      },
+      "velocity": 1.565762004010972,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 100,
+      "absY": 0,
+      "deltaX": -100,
+      "deltaY": 0,
+      "dir": "Right",
+      "event": Object {
+        "clientX": 200,
+        "clientY": 100,
+        "preventDefault": [Function],
+        "timeStamp": 1374873.499999987,
+      },
+      "velocity": 1.5624999996816769,
+    },
+  ],
+]
+`;
+
+exports[`useSwipeable handles touch events and fires correct props: useSwipeable onSwiped trackTouch 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 100,
+      "deltaX": 0,
+      "deltaY": -100,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "touches": Array [
+          Object {
+            "clientX": undefined,
+            "clientY": undefined,
+          },
+        ],
+      },
+      "velocity": 1.8903591679142773,
+    },
+  ],
+]
+`;
+
+exports[`useSwipeable handles touch events and fires correct props: useSwipeable onSwiping trackTouch 1`] = `
+Array [
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 25,
+      "deltaX": 0,
+      "deltaY": -25,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8100.999999966007,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 125,
+          },
+        ],
+      },
+      "velocity": 1.0548523197963273,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 50,
+      "deltaX": 0,
+      "deltaY": -50,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8116.899999964517,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 150,
+          },
+        ],
+      },
+      "velocity": 1.2626262620442454,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 75,
+      "deltaX": 0,
+      "deltaY": -75,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8122.799999953713,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 175,
+          },
+        ],
+      },
+      "velocity": 1.6483516480817324,
+    },
+  ],
+  Array [
+    Object {
+      "absX": 0,
+      "absY": 100,
+      "deltaX": 0,
+      "deltaY": -100,
+      "dir": "Down",
+      "event": Object {
+        "preventDefault": [Function],
+        "timeStamp": 8130.199999955433,
+        "touches": Array [
+          Object {
+            "clientX": 100,
+            "clientY": 200,
+          },
+        ],
+      },
+      "velocity": 1.8903591679142773,
+    },
+  ],
+]
+`;

--- a/src/__tests__/helpers/events.js
+++ b/src/__tests__/helpers/events.js
@@ -1,25 +1,19 @@
 function createClientXYObject(x, y) {
   return { clientX: x, clientY: y }
 }
-
-export function createTouchEventObject({
-  x = 0,
-  y = 0,
-  preventDefault = () => {}
-}) {
+const preventDefault = () => {}
+export function createTouchEventObject({ x, y, ...rest }) {
   return {
     touches: [createClientXYObject(x, y)],
-    preventDefault
+    preventDefault,
+    ...rest
   }
 }
 
-export function createMouseEventObject({
-  x = 0,
-  y = 0,
-  preventDefault = () => {}
-}) {
+export function createMouseEventObject({ x, y, ...rest }) {
   return {
     ...createClientXYObject(x, y),
-    preventDefault
+    preventDefault,
+    ...rest
   }
 }

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -4,8 +4,8 @@ import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { Swipeable, useSwipeable, LEFT, RIGHT, UP, DOWN } from '../index'
 import {
-  createTouchEventObject,
-  createMouseEventObject
+  createTouchEventObject as cte,
+  createMouseEventObject as cme
 } from './helpers/events'
 
 const { mount } = Enzyme
@@ -103,22 +103,34 @@ function setupGetMountedComponent(type) {
       const touchHere = wrapper.find('span')
       touchHere.simulate(
         'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
+        cte({ x: 100, y: 100, timeStamp: 8077.299999946263 })
       )
 
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 175 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 200 }))
-      eventListenerMap.touchend(createTouchEventObject({}))
+      eventListenerMap.touchmove(
+        cte({ x: 100, y: 125, timeStamp: 8100.999999966007 })
+      )
+      eventListenerMap.touchmove(
+        cte({ x: 100, y: 150, timeStamp: 8116.899999964517 })
+      )
+      eventListenerMap.touchmove(
+        cte({ x: 100, y: 175, timeStamp: 8122.799999953713 })
+      )
+      eventListenerMap.touchmove(
+        cte({ x: 100, y: 200, timeStamp: 8130.199999955433 })
+      )
+      eventListenerMap.touchend(cte({}))
 
       expect(swipeFuncs.onSwipedDown).toHaveBeenCalled()
       expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedRight).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwiped).toHaveBeenCalled()
-      expect(swipeFuncs.onSwiping).toHaveBeenCalledTimes(4)
-      expectSwipingDir(swipeFuncs.onSwiping, DOWN)
+      expect(swipeFuncs.onSwiped.mock.calls).toMatchSnapshot(
+        `${type} onSwiped trackTouch`
+      )
+      expect(swipeFuncs.onSwiping.mock.calls).toMatchSnapshot(
+        `${type} onSwiping trackTouch`
+      )
+
       wrapper.unmount()
     })
 
@@ -132,22 +144,33 @@ function setupGetMountedComponent(type) {
       const touchHere = wrapper.find('span')
       touchHere.simulate(
         'mouseDown',
-        createMouseEventObject({ x: 100, y: 100 })
+        cme({ x: 100, y: 100, timeStamp: 1374809.499999974 })
       )
 
-      eventListenerMap.mousemove(createMouseEventObject({ x: 125, y: 100 }))
-      eventListenerMap.mousemove(createMouseEventObject({ x: 150, y: 100 }))
-      eventListenerMap.mousemove(createMouseEventObject({ x: 175, y: 100 }))
-      eventListenerMap.mousemove(createMouseEventObject({ x: 200, y: 100 }))
+      eventListenerMap.mousemove(
+        cme({ x: 125, y: 100, timeStamp: 1374825.199999963 })
+      )
+      eventListenerMap.mousemove(
+        cme({ x: 150, y: 100, timeStamp: 1374841.3999999757 })
+      )
+      eventListenerMap.mousemove(
+        cme({ x: 175, y: 100, timeStamp: 1374857.399999979 })
+      )
+      eventListenerMap.mousemove(
+        cme({ x: 200, y: 100, timeStamp: 1374873.499999987 })
+      )
       eventListenerMap.mouseup({})
 
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalled()
       expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedDown).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwiped).toHaveBeenCalled()
-      expect(swipeFuncs.onSwiping).toHaveBeenCalledTimes(4)
-      expectSwipingDir(swipeFuncs.onSwiping, RIGHT)
+      expect(swipeFuncs.onSwiped.mock.calls).toMatchSnapshot(
+        `${type} onSwiped trackMouse`
+      )
+      expect(swipeFuncs.onSwiping.mock.calls).toMatchSnapshot(
+        `${type} onSwiping trackMouse`
+      )
 
       wrapper.unmount()
     })
@@ -163,23 +186,12 @@ function setupGetMountedComponent(type) {
       })
 
       const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100, ...e })
-      )
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100, ...e }))
 
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 125, ...e })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 150, ...e })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 175, ...e })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 200, ...e })
-      )
+      eventListenerMap.touchmove(cte({ x: 100, y: 125, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 150, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 175, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 200, ...e }))
       eventListenerMap.touchend({ ...e })
 
       expect(onSwipedDown).toHaveBeenCalled()
@@ -200,21 +212,12 @@ function setupGetMountedComponent(type) {
       })
 
       const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'touchstart',
-        createTouchEventObject({ x: 100, y: 100, ...e })
-      )
+      touchHere.simulate('touchstart', cte({ x: 100, y: 100, ...e }))
 
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 75, ...e })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 50, ...e })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 25, ...e })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 5, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 75, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 50, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 25, ...e }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 5, ...e }))
       eventListenerMap.touchend({ ...e })
 
       expect(onSwipedUp).toHaveBeenCalled()
@@ -230,17 +233,10 @@ function setupGetMountedComponent(type) {
       const wrapper = getMountedComponent({ onSwiping })
 
       const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100, preventDefault })
-      )
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100, preventDefault }))
 
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 50, preventDefault })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 5, preventDefault })
-      )
+      eventListenerMap.touchmove(cte({ x: 100, y: 50, preventDefault }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 5, preventDefault }))
       eventListenerMap.touchend({ preventDefault })
 
       expect(onSwiping).toHaveBeenCalled()
@@ -255,17 +251,10 @@ function setupGetMountedComponent(type) {
       const wrapper = getMountedComponent({ onSwiped })
 
       const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100, preventDefault })
-      )
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100, preventDefault }))
 
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 50, preventDefault })
-      )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 5, preventDefault })
-      )
+      eventListenerMap.touchmove(cte({ x: 100, y: 50, preventDefault }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 5, preventDefault }))
       eventListenerMap.touchend({ preventDefault })
 
       expect(onSwiped).toHaveBeenCalled()
@@ -287,13 +276,10 @@ function setupGetMountedComponent(type) {
       })
 
       const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
 
-      eventListenerMap.touchmove(createTouchEventObject({ x: 145, y: 100 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 80, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 145, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 80, y: 100 }))
       eventListenerMap.touchend({})
 
       expect(onSwiping).toHaveBeenCalledTimes(2)
@@ -314,48 +300,36 @@ function setupGetMountedComponent(type) {
       const touchHere = wrapper.find('span')
 
       // check right
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsRight, RIGHT)
 
       // check left
       const swipeFuncsLeft = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsLeft, rotationAngle: 90 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 75 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 50 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 75 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 50 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsLeft, LEFT)
 
       // check up
       const swipeFuncsUp = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsUp, rotationAngle: 90 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 125, y: 100 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 150, y: 100 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 125, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 150, y: 100 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsUp, UP)
 
       // check down
       const swipeFuncsDown = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsDown, rotationAngle: 90 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 75, y: 100 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 50, y: 100 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 75, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 50, y: 100 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsDown, DOWN)
 
@@ -372,24 +346,18 @@ function setupGetMountedComponent(type) {
       const touchHere = wrapper.find('span')
 
       // check -90
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsNegativeRotation, 'Left')
 
       // check 360 + 270
       const swipeFuncsLargeRotation = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsLargeRotation, rotationAngle: 360 + 270 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsLargeRotation, 'Left')
 
@@ -403,54 +371,42 @@ function setupGetMountedComponent(type) {
       const touchHere = wrapper.find('span')
 
       // check 0
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 125, y: 100 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 150, y: 100 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 125, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 150, y: 100 }))
       eventListenerMap.touchend({})
       expect(swipeFuncs.onSwiped).toHaveBeenCalledTimes(1)
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalledTimes(1)
 
       // check 90
       wrapper.setProps({ rotationAngle: 90 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
       expect(swipeFuncs.onSwiped).toHaveBeenCalledTimes(2)
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalledTimes(2)
 
       // check 180
       wrapper.setProps({ rotationAngle: 180 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 75, y: 100 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 50, y: 100 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 75, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 50, y: 100 }))
       eventListenerMap.touchend({})
       expect(swipeFuncs.onSwiped).toHaveBeenCalledTimes(3)
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalledTimes(3)
 
       // check 270
       wrapper.setProps({ rotationAngle: 270 })
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 75 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 50 }))
+      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 75 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 50 }))
       eventListenerMap.touchend({})
       expect(swipeFuncs.onSwiped).toHaveBeenCalledTimes(4)
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalledTimes(4)
 
       expect(swipeFuncs.onSwiping).toHaveBeenCalledTimes(8)
-      ;['Left', 'Up', 'Down'].forEach(dir => {
+      ;[LEFT, UP, DOWN].forEach(dir => {
         expect(swipeFuncs[`onSwiped${dir}`]).not.toHaveBeenCalled()
       })
 

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import { Swipeable, useSwipeable } from '../index'
+import { Swipeable, useSwipeable, LEFT, RIGHT, UP, DOWN } from '../index'
 import {
   createTouchEventObject,
   createMouseEventObject
@@ -12,21 +12,31 @@ const { mount } = Enzyme
 
 Enzyme.configure({ adapter: new Adapter() })
 
-const DIRECTIONS = ['Left', 'Right', 'Up', 'Down']
+const DIRECTIONS = [LEFT, RIGHT, UP, DOWN]
 
 function getMockedSwipeFunctions() {
   return DIRECTIONS.reduce(
-    (acc, dir) => {
-      acc[`onSwiped${dir}`] = jest.fn() // eslint-disable-line
-      acc[`onSwiping${dir}`] = jest.fn() // eslint-disable-line
-      return acc
-    },
-    {
-      onSwiping: jest.fn(),
-      onSwiped: jest.fn()
-    }
+    (acc, dir) => ({ ...acc, [`onSwiped${dir}`]: jest.fn() }),
+    { onSwiping: jest.fn(), onSwiped: jest.fn() }
   )
 }
+
+function expectSwipingDir(fns, dir) {
+  fns.mock.calls.forEach(call => {
+    expect(call[0].dir).toBe(dir)
+  })
+}
+
+const expectSwipeFuncsDir = (sf, dir) =>
+  Object.keys(sf).forEach(s => {
+    if (s.endsWith(dir) || s === 'onSwiped') {
+      expect(sf[s]).toHaveBeenCalled()
+    } else if (s === 'onSwiping') {
+      expectSwipingDir(sf[s], dir)
+    } else {
+      expect(sf[s]).not.toHaveBeenCalled()
+    }
+  })
 
 function mockListenerSetup(el) {
   // track eventListener adds to trigger later
@@ -34,7 +44,6 @@ function mockListenerSetup(el) {
   const eventListenerMap = {}
   el.addEventListener = jest.fn((event, cb) => {
     // eslint-disable-line no-param-reassign
-    // console.log('add-', event, cb);
     eventListenerMap[event] = cb
   })
   el.removeEventListener = jest.fn((event, cb) => {
@@ -89,8 +98,7 @@ function setupGetMountedComponent(type) {
 
     it('handles touch events and fires correct props', () => {
       const swipeFuncs = getMockedSwipeFunctions()
-      const onTap = jest.fn()
-      const wrapper = getMountedComponent({ ...swipeFuncs, onTap })
+      const wrapper = getMountedComponent({ ...swipeFuncs })
 
       const touchHere = wrapper.find('span')
       touchHere.simulate(
@@ -105,28 +113,20 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchend(createTouchEventObject({}))
 
       expect(swipeFuncs.onSwipedDown).toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingDown).toHaveBeenCalledTimes(4)
       expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingUp).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingLeft).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedRight).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingRight).not.toHaveBeenCalled()
-      expect(onTap).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwiped).toHaveBeenCalled()
       expect(swipeFuncs.onSwiping).toHaveBeenCalledTimes(4)
+      expectSwipingDir(swipeFuncs.onSwiping, DOWN)
       wrapper.unmount()
     })
 
     it('handles mouse events with trackMouse prop and fires correct props', () => {
       const swipeFuncs = getMockedSwipeFunctions()
-      const onMouseDown = jest.fn()
-      const onTap = jest.fn()
       const wrapper = getMountedComponent({
         ...swipeFuncs,
-        onMouseDown,
-        trackMouse: true,
-        onTap
+        trackMouse: true
       })
 
       const touchHere = wrapper.find('span')
@@ -142,96 +142,58 @@ function setupGetMountedComponent(type) {
       eventListenerMap.mouseup({})
 
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingRight).toHaveBeenCalledTimes(4)
       expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingUp).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedDown).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingDown).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingLeft).not.toHaveBeenCalled()
-      expect(onTap).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwiped).toHaveBeenCalled()
       expect(swipeFuncs.onSwiping).toHaveBeenCalledTimes(4)
+      expectSwipingDir(swipeFuncs.onSwiping, RIGHT)
 
-      // still calls passed through mouse event prop
-      // TODO: FIGURE THIS OUT?!
-      // expect(onMouseDown).toHaveBeenCalled();
       wrapper.unmount()
     })
 
-    it('calls onTap', () => {
-      const swipeFuncs = getMockedSwipeFunctions()
-      const onTap = jest.fn()
-      const wrapper = getMountedComponent({ ...swipeFuncs, onTap })
-
-      const touchHere = wrapper.find('span')
-      // simulate what is probably a light tap,
-      // meaning the user "swiped" just a little, but less than the delta
-      touchHere.simulate(
-        'touchStart',
-        createTouchEventObject({ x: 100, y: 100 })
-      )
-
-      eventListenerMap.touchmove(createTouchEventObject({ x: 103, y: 100 }))
-      eventListenerMap.touchmove(createTouchEventObject({ x: 107, y: 100 }))
-      eventListenerMap.touchend({})
-
-      expect(swipeFuncs.onSwipedRight).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingRight).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingUp).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipedDown).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingDown).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwipingLeft).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwiped).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwiping).not.toHaveBeenCalled()
-
-      expect(onTap).toHaveBeenCalled()
-      wrapper.unmount()
-    })
-
-    it('calls preventDefault correctly when swiping in direction that has a callback', () => {
+    it('calls preventDefault + stopPropagation when swiping in direction that has a callback', () => {
       const onSwipedDown = jest.fn()
       const preventDefault = jest.fn()
-      const wrapper = mount(
-        <Swipeable
-          onSwipedDown={onSwipedDown}
-          preventDefaultTouchmoveEvent={true}
-        >
-          <span>Touch Here</span>
-        </Swipeable>
-      )
+      const stopPropagation = jest.fn()
+      const e = { preventDefault, stopPropagation }
+      const wrapper = getMountedComponent({
+        onSwipedDown,
+        stopPropagation: true
+      })
 
       const touchHere = wrapper.find('span')
       touchHere.simulate(
         'touchStart',
-        createTouchEventObject({ x: 100, y: 100, preventDefault })
+        createTouchEventObject({ x: 100, y: 100, ...e })
       )
 
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 125, preventDefault })
+        createTouchEventObject({ x: 100, y: 125, ...e })
       )
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 150, preventDefault })
+        createTouchEventObject({ x: 100, y: 150, ...e })
       )
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 175, preventDefault })
+        createTouchEventObject({ x: 100, y: 175, ...e })
       )
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 200, preventDefault })
+        createTouchEventObject({ x: 100, y: 200, ...e })
       )
-      eventListenerMap.touchend({ preventDefault })
+      eventListenerMap.touchend({ ...e })
 
       expect(onSwipedDown).toHaveBeenCalled()
 
       expect(preventDefault).toHaveBeenCalledTimes(4)
+      expect(stopPropagation).toHaveBeenCalledTimes(5)
       wrapper.unmount()
     })
 
     it('does not call preventDefault when false', () => {
       const onSwipedUp = jest.fn()
       const preventDefault = jest.fn()
+      const stopPropagation = jest.fn()
+      const e = { preventDefault, stopPropagation }
       const wrapper = getMountedComponent({
         onSwipedUp,
         preventDefaultTouchmoveEvent: false
@@ -240,26 +202,25 @@ function setupGetMountedComponent(type) {
       const touchHere = wrapper.find('span')
       touchHere.simulate(
         'touchstart',
-        createTouchEventObject({ x: 100, y: 100, preventDefault })
+        createTouchEventObject({ x: 100, y: 100, ...e })
       )
 
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 75, preventDefault })
+        createTouchEventObject({ x: 100, y: 75, ...e })
       )
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 50, preventDefault })
+        createTouchEventObject({ x: 100, y: 50, ...e })
       )
       eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 25, preventDefault })
+        createTouchEventObject({ x: 100, y: 25, ...e })
       )
-      eventListenerMap.touchmove(
-        createTouchEventObject({ x: 100, y: 5, preventDefault })
-      )
-      eventListenerMap.touchend({ preventDefault })
+      eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 5, ...e }))
+      eventListenerMap.touchend({ ...e })
 
       expect(onSwipedUp).toHaveBeenCalled()
 
       expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
       wrapper.unmount()
     })
 
@@ -316,13 +277,9 @@ function setupGetMountedComponent(type) {
     it('does not re-check delta when swiping already in progress', () => {
       const onSwiping = jest.fn()
       const onSwipedRight = jest.fn()
-      const onSwipingRight = jest.fn()
-      const onSwipingLeft = jest.fn()
       const onSwipedLeft = jest.fn()
       const wrapper = getMountedComponent({
         onSwiping,
-        onSwipingLeft,
-        onSwipingRight,
         onSwipedRight,
         onSwipedLeft,
         trackMouse: true,
@@ -340,8 +297,8 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchend({})
 
       expect(onSwiping).toHaveBeenCalledTimes(2)
-      expect(onSwipingRight).toHaveBeenCalledTimes(1)
-      expect(onSwipingLeft).toHaveBeenCalledTimes(1)
+      expect(onSwiping.mock.calls[0][0].dir).toBe(RIGHT)
+      expect(onSwiping.mock.calls[1][0].dir).toBe(LEFT)
       expect(onSwipedLeft).toHaveBeenCalledTimes(1)
       expect(onSwipedRight).not.toHaveBeenCalled()
       wrapper.unmount()
@@ -356,15 +313,6 @@ function setupGetMountedComponent(type) {
       })
       const touchHere = wrapper.find('span')
 
-      const expectDir = (sf, dir) =>
-        Object.keys(sf).forEach(s => {
-          if (s.endsWith(dir) || s === 'onSwiped' || s === 'onSwiping') {
-            expect(sf[s]).toHaveBeenCalled()
-          } else {
-            expect(sf[s]).not.toHaveBeenCalled()
-          }
-        })
-
       // check right
       touchHere.simulate(
         'touchStart',
@@ -373,7 +321,7 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
-      expectDir(swipeFuncsRight, 'Right')
+      expectSwipeFuncsDir(swipeFuncsRight, RIGHT)
 
       // check left
       const swipeFuncsLeft = getMockedSwipeFunctions()
@@ -385,7 +333,7 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 75 }))
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 50 }))
       eventListenerMap.touchend({})
-      expectDir(swipeFuncsLeft, 'Left')
+      expectSwipeFuncsDir(swipeFuncsLeft, LEFT)
 
       // check up
       const swipeFuncsUp = getMockedSwipeFunctions()
@@ -397,7 +345,7 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchmove(createTouchEventObject({ x: 125, y: 100 }))
       eventListenerMap.touchmove(createTouchEventObject({ x: 150, y: 100 }))
       eventListenerMap.touchend({})
-      expectDir(swipeFuncsUp, 'Up')
+      expectSwipeFuncsDir(swipeFuncsUp, UP)
 
       // check down
       const swipeFuncsDown = getMockedSwipeFunctions()
@@ -409,7 +357,7 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchmove(createTouchEventObject({ x: 75, y: 100 }))
       eventListenerMap.touchmove(createTouchEventObject({ x: 50, y: 100 }))
       eventListenerMap.touchend({})
-      expectDir(swipeFuncsDown, 'Down')
+      expectSwipeFuncsDir(swipeFuncsDown, DOWN)
 
       wrapper.unmount()
     })
@@ -423,15 +371,6 @@ function setupGetMountedComponent(type) {
       })
       const touchHere = wrapper.find('span')
 
-      const expectDir = (sf, dir) =>
-        Object.keys(sf).forEach(s => {
-          if (s.endsWith(dir) || s === 'onSwiped' || s === 'onSwiping') {
-            expect(sf[s]).toHaveBeenCalled()
-          } else {
-            expect(sf[s]).not.toHaveBeenCalled()
-          }
-        })
-
       // check -90
       touchHere.simulate(
         'touchStart',
@@ -440,7 +379,7 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
-      expectDir(swipeFuncsNegativeRotation, 'Left')
+      expectSwipeFuncsDir(swipeFuncsNegativeRotation, 'Left')
 
       // check 360 + 270
       const swipeFuncsLargeRotation = getMockedSwipeFunctions()
@@ -452,7 +391,7 @@ function setupGetMountedComponent(type) {
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 125 }))
       eventListenerMap.touchmove(createTouchEventObject({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
-      expectDir(swipeFuncsLargeRotation, 'Left')
+      expectSwipeFuncsDir(swipeFuncsLargeRotation, 'Left')
 
       wrapper.unmount()
     })
@@ -513,7 +452,6 @@ function setupGetMountedComponent(type) {
       expect(swipeFuncs.onSwiping).toHaveBeenCalledTimes(8)
       ;['Left', 'Up', 'Down'].forEach(dir => {
         expect(swipeFuncs[`onSwiped${dir}`]).not.toHaveBeenCalled()
-        expect(swipeFuncs[`onSwiping${dir}`]).not.toHaveBeenCalled()
       })
 
       wrapper.unmount()

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ const defaultProps = {
   eventListenerOptions: passive,
   preventDefaultTouchmoveEvent: true,
   stopPropagation: false,
-  flickThreshold: 0.6,
   delta: 10,
   rotationAngle: 0,
   trackMouse: false,
@@ -19,16 +18,16 @@ const initialState = {
   lastEventData: undefined,
   start: undefined
 }
-const LEFT = 'Left'
-const RIGHT = 'Right'
-const UP = 'Up'
-const DOWN = 'Down'
+export const LEFT = 'Left'
+export const RIGHT = 'Right'
+export const UP = 'Up'
+export const DOWN = 'Down'
 const touchMove = 'touchmove'
 const touchEnd = 'touchend'
 const mouseMove = 'mousemove'
 const mouseUp = 'mouseup'
 
-function getDirection({ absX, absY, deltaX, deltaY }) {
+function getDirection(absX, absY, deltaX, deltaY) {
   if (absX > absY) {
     if (deltaX > 0) {
       return LEFT
@@ -56,15 +55,9 @@ function getHandlers(set, props) {
     if (event.touches && event.touches.length > 1) return
 
     set(() => {
-      const { clientX: x, clientY: y } = event.touches
-        ? event.touches[0]
-        : event
-      const xy = rotateXYByAngle([x, y], props.rotationAngle)
-      return {
-        ...initialState,
-        xy,
-        start: Date.now()
-      }
+      const { clientX, clientY } = event.touches ? event.touches[0] : event
+      const xy = rotateXYByAngle([clientX, clientY], props.rotationAngle)
+      return { ...initialState, xy, start: Date.now() }
     })
   }
 
@@ -92,21 +85,15 @@ function getHandlers(set, props) {
 
       if (props.stopPropagation) event.stopPropagation()
 
-      const eventData = { event, deltaX, deltaY, absX, absY, velocity }
+      const dir = getDirection(absX, absY, deltaX, deltaY)
+      const eventData = { event, absX, absY, deltaX, deltaY, velocity, dir }
 
       props.onSwiping && props.onSwiping(eventData)
 
       // track if a swipe is cancelable
       // so we can call prevenDefault if needed
       let cancelablePageSwipe = false
-      if (props.onSwiping || props.onSwiped) {
-        cancelablePageSwipe = true
-      }
-
-      const dir = getDirection(eventData)
-
-      if (props[`onSwiping${dir}`] || props[`onSwiped${dir}`]) {
-        props[`onSwiping${dir}`] && props[`onSwiping${dir}`](eventData)
+      if (props.onSwiping || props.onSwiped || props[`onSwiped${dir}`]) {
         cancelablePageSwipe = true
       }
 
@@ -122,17 +109,12 @@ function getHandlers(set, props) {
       if (state.swiping) {
         if (props.stopPropagation) event.stopPropagation()
 
-        const isFlick = state.velocity > props.flickThreshold
-
-        const eventData = { ...state.lastEventData, event, isFlick }
+        const eventData = { ...state.lastEventData, event }
 
         props.onSwiped && props.onSwiped(eventData)
 
-        const dir = getDirection(eventData)
-
-        props[`onSwiped${dir}`] && props[`onSwiped${dir}`](eventData)
-      } else {
-        props.onTap && props.onTap({ ...state, event })
+        props[`onSwiped${eventData.dir}`] &&
+          props[`onSwiped${eventData.dir}`](eventData)
       }
       return { ...initialState }
     })
@@ -196,16 +178,10 @@ export class Swipeable extends React.Component {
   static propTypes = {
     onSwiped: PropTypes.func,
     onSwiping: PropTypes.func,
-    onSwipingUp: PropTypes.func,
-    onSwipingRight: PropTypes.func,
-    onSwipingDown: PropTypes.func,
-    onSwipingLeft: PropTypes.func,
     onSwipedUp: PropTypes.func,
     onSwipedRight: PropTypes.func,
     onSwipedDown: PropTypes.func,
     onSwipedLeft: PropTypes.func,
-    onTap: PropTypes.func,
-    flickThreshold: PropTypes.number,
     delta: PropTypes.number,
     preventDefaultTouchmoveEvent: PropTypes.bool,
     stopPropagation: PropTypes.bool,
@@ -228,8 +204,8 @@ export class Swipeable extends React.Component {
   }
 
   render() {
-    const handlers = getHandlers(this._set, this.props)
-    const { className, style, nodeName = 'div', innerRef } = this.props
+    const { className, style, nodeName = 'div', innerRef, ...rest } = this.props
+    const handlers = getHandlers(this._set, rest)
     return React.createElement(
       nodeName,
       { ...handlers, className, style, ref: innerRef },


### PR DESCRIPTION
- use constants for left, right, up, and down
- removed `onSwipingUp`, `onSwipingRight`, `onSwipingDown`, `onSwipingLeft`
  - added `dir`ection to callback for `onSwiping`
- remove `onTap`
- remove `flickThreshold ` prop, and `isFlick`