### PR TITLE
fix eslint error: add curly braces to innerRef example and spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ as well as the x distance, + or -, from where the swipe started to where it ende
 
 **`disabled`** will disable `<Swipeable>`: swipes will not be tracked and this stops current active swipes from triggering anymore prop callbacks. The default value is `false`.
 
-**`innerRef`** will allow access to the Swipeable's inner dom node element react ref. See [#81](https://github.com/dogfessional/react-swipeable/issues/81) for more details. Example usage `<Swipeable innerRef={(el) => this.swipeableEl = el} >`. Then you'll have access to the dom element that Swipeable uses internally.
+**`innerRef`** will allow access to the Swipeable's inner dom node element react ref. See [#81](https://github.com/dogfessional/react-swipeable/issues/81) for more details. Example usage `<Swipeable innerRef={(el) => { this.swipeableEl = el; }} >`. Then you'll have access to the dom element that Swipeable uses internally.
 
 **`rotationAngle`** will allow to set a rotation angle, e.g. for a four-player game on a tablet, where each player has a 90° turned view. The default value is `0`.
 

--- a/src/__tests__/Swipeable.spec.js
+++ b/src/__tests__/Swipeable.spec.js
@@ -377,7 +377,7 @@ describe('Swipeable', () => {
   it('should pass ref to the component via innerRef prop', () => {
     const WrapperComp = class extends React.Component {
       render() {
-        return <Swipeable innerRef={el => this.testRef = el} /> // eslint-disable-line
+        return <Swipeable innerRef={(el) => { this.testRef = el; }} />;
       }
     };
     const wrapper = mount((<WrapperComp />));


### PR DESCRIPTION
We started using this package today and I noticed that a colleague of mine had added an `eslint-disable-next-line` comment for the innerRef prop because of a `no-return-assign` error https://eslint.org/docs/rules/no-return-assign. 

He told me, that it was exactly the example code from the readme.
```jsx
<Swipeable innerRef={(el) => this.swipeableEl = el} >
```
That was easy to fix, because arrow functions without curly braces actually have a hidden return. The old example is equivalent to
```jsx
<Swipeable innerRef={(el) => { return this.swipeableEl = el; }} >
```
so we just added the curly braces and omitted the return. When I saw that there was an `eslint-disable-line` comment in your code aswell, I had to chuckle and create this PR 😄