### PR TITLE
setup single touchmove event listener

### DIFF
--- a/examples/app/FeatureTestConsole.js
+++ b/examples/app/FeatureTestConsole.js
@@ -27,6 +27,9 @@ const initialStateSwipeable = {
   rotationAngle: 0,
 };
 const initialStateApplied = {
+  showHook: true,
+  showComponent: true,
+  showOnSwipeds: false,
   onSwipingApplied: true,
   onSwipedApplied: true,
   onSwipedLeftApplied: true,
@@ -100,6 +103,9 @@ export default class Main extends Component {
       swipingDirection,
       swipedDirection,
       delta,
+      showHook,
+      showComponent,
+      showOnSwipeds,
       onSwipingApplied,
       onSwipedApplied,
       persistEvent,
@@ -129,7 +135,7 @@ export default class Main extends Component {
       <div className="row" id="FeatureTestConsole">
         <div className="small-12 column">
           <h5><strong>Test react-swipeable features.</strong></h5>
-          <Swipeable
+          {showComponent && <Swipeable
             {...boundSwipes}
             {...swipeableDirProps}
             delta={deltaNum}
@@ -144,7 +150,23 @@ export default class Main extends Component {
                 <p>See output below and check the console for 'onSwiping' and 'onSwiped' callback output(open dev tools)</p>
                 <span>You can also 'toggle' the swip(ed/ing) props being applied to this container below.</span>
               </div>
-          </Swipeable>
+          </Swipeable>}
+          {showHook && <SwipeableHook
+            {...boundSwipes}
+            {...swipeableDirProps}
+            delta={deltaNum}
+            preventDefaultTouchmoveEvent={preventDefaultTouchmoveEvent}
+            trackTouch={trackTouch}
+            trackMouse={trackMouse}
+            rotationAngle={rotationAngleNum}
+            className="callout"
+            style={swipeableStyle}>
+              <div onTouchStart={()=>this.resetState()}>
+                <h5>Hook - Swipe inside here to test</h5>
+                <p>See output below and check the console for 'onSwiping' and 'onSwiped' callback output(open dev tools)</p>
+                <span>You can also 'toggle' the swip(ed/ing) props being applied to this container below.</span>
+              </div>
+          </SwipeableHook>}
           <table>
             <thead>
               <tr><th>Applied?</th><th>Action</th><th>Output</th></tr>
@@ -169,9 +191,26 @@ export default class Main extends Component {
                 <td>onSwiping Direction</td><td>{swipingDirection}</td>
               </tr>
               <tr>
-                <td className="text-center"><a href="#appliedDirs">↓&nbsp;Below&nbsp;↓</a></td>
+                <td className="text-center">
+                  <a href="#" onClick={(e)=>(e.preventDefault(),this.updateValue('showOnSwipeds', !showOnSwipeds))}>
+                    {showOnSwipeds ? '↑ Hide ↑' : '↓ Show ↓'}
+                  </a>
+                </td>
                 <td>onSwiped Direction</td><td>{swipedDirection}</td>
               </tr>
+              {showOnSwipeds && <tr>
+                <td className="text-center" colSpan="3">
+                  <table id="appliedDirs">
+                    <thead>
+                      <tr><th colSpan="2" className="text-center">onSwiped</th></tr>
+                      <tr><th>Applied?</th><th>Direction</th></tr>
+                    </thead>
+                    <tbody>
+                      {DIRECTIONS.map(this._renderAppliedDirRow.bind(this))}
+                    </tbody>
+                  </table>
+                </td>
+              </tr>}
               <tr>
                 <td colSpan="2" className="text-center">delta:</td>
                 <td>
@@ -212,15 +251,24 @@ export default class Main extends Component {
                     onChange={(e)=>this.updateValue('persistEvent', e.target.checked)}/>
                 </td>
               </tr>
-            </tbody>
-          </table>
-          <table id="appliedDirs">
-            <thead>
-              <tr><th colSpan="2" className="text-center">onSwiped</th></tr>
-              <tr><th>Applied?</th><th>Direction</th></tr>
-            </thead>
-            <tbody>
-              {DIRECTIONS.map(this._renderAppliedDirRow.bind(this))}
+              <tr>
+                <td colSpan="2" className="text-center">Show Hook Example:</td>
+                <td style={{textAlign: "center"}}>
+                  <input style={{margin: "0px"}}
+                    type="checkbox"
+                    checked={showHook}
+                    onChange={(e)=>this.updateValue('showHook', e.target.checked)}/>
+                </td>
+              </tr>
+              <tr>
+                <td colSpan="2" className="text-center">Show Component Example:</td>
+                <td style={{textAlign: "center"}}>
+                  <input style={{margin: "0px"}}
+                    type="checkbox"
+                    checked={showComponent}
+                    onChange={(e)=>this.updateValue('showComponent', e.target.checked)}/>
+                </td>
+              </tr>
             </tbody>
           </table>
           <table style={{width: "100%"}}>

--- a/examples/app/FeatureTestConsole.js
+++ b/examples/app/FeatureTestConsole.js
@@ -145,22 +145,6 @@ export default class Main extends Component {
                 <span>You can also 'toggle' the swip(ed/ing) props being applied to this container below.</span>
               </div>
           </Swipeable>
-          <SwipeableHook
-            {...boundSwipes}
-            {...swipeableDirProps}
-            delta={deltaNum}
-            preventDefaultTouchmoveEvent={preventDefaultTouchmoveEvent}
-            trackTouch={trackTouch}
-            trackMouse={trackMouse}
-            rotationAngle={rotationAngleNum}
-            className="callout"
-            style={swipeableStyle}>
-              <div onTouchStart={()=>this.resetState()}>
-                <h5>Hook - Swipe inside here to test</h5>
-                <p>See output below and check the console for 'onSwiping' and 'onSwiped' callback output(open dev tools)</p>
-                <span>You can also 'toggle' the swip(ed/ing) props being applied to this container below.</span>
-              </div>
-          </SwipeableHook>
           <table>
             <thead>
               <tr><th>Applied?</th><th>Action</th><th>Output</th></tr>

--- a/src/index.js
+++ b/src/index.js
@@ -58,10 +58,11 @@ const noop = () => {}
 let touchMoveListenerSetup = false
 let handlerToCall = noop
 let touchMoveHandlerOption = {}
+const setTouchMoveHandler = newH => (handlerToCall = newH)
 const touchMoveHandler = e => {
   handlerToCall(e)
 }
-const setupTouchMoveListener = (newHandler, touchHandlerOption) => {
+const setupTouchMoveListener = touchHandlerOption => {
   // cleanup and reset if preventDefaultTouchMoveEvent changed
   if (typeof touchHandlerOption === 'object' && touchMoveListenerSetup) {
     if (touchHandlerOption.passive !== touchMoveHandlerOption.passive) {
@@ -78,8 +79,6 @@ const setupTouchMoveListener = (newHandler, touchHandlerOption) => {
     )
     touchMoveListenerSetup = true
   }
-  // assign single handler to call
-  handlerToCall = newHandler
 }
 
 // clean up the single 'touchmove' eventListener
@@ -172,6 +171,7 @@ function getHandlers(set, props) {
     if (props.trackTouch) {
       const touchHandlerOption = getTouchHandlerOption(props)
       document.addEventListener(touchEnd, onUp, touchHandlerOption)
+      setTouchMoveHandler(onMove)
     }
     onStart(e)
   }
@@ -194,7 +194,7 @@ function getHandlers(set, props) {
 
   if (props.trackTouch) {
     const touchHandlerOption = getTouchHandlerOption(props)
-    setupTouchMoveListener(onMove, touchHandlerOption)
+    setupTouchMoveListener(touchHandlerOption)
   }
 
   const output = {}
@@ -216,6 +216,9 @@ export function useSwipeable(props) {
       ...currentProps
     })
   )
+  React.useEffect(() => {
+    return () => cleanUp()
+  }, [])
   return spread(props)
 }
 


### PR DESCRIPTION
WIP

Setup single `touchmove` listener and setup the `touchmove` before any swiping starts.

alternate solution for #127. other possible solution is #129 

- partially used solution from https://github.com/Shopify/draggable/pull/200
- also partially based on v4 of swipeable, [setting up touchmove listener before](https://github.com/dogfessional/react-swipeable/blob/4.x/src/Swipeable.js#L114)
- setup a single `touchmove` event listener and set it up **before** any swiping starts
- works for both `<Swipeable />` and `useSwipeable`

Additional fixes:
- also fixes this bug that should allow for `false` when `touchHandlerOption` prop is not `undefined`
  - this is a fix when/if users pass in `false` when an options object is not supported
    - *ie. older browsers*

Tasks:
- [ ] update/add tests
- [x] fix example(s)