### PR TITLE
Preventdefault touch ios fix2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,14 @@
     "node": true
   },
   "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "semi": false,
+        "printWidth": 100
+      }
+    ],
     "valid-jsdoc": 2,
     "react/jsx-uses-react": 1,
     "react/jsx-no-undef": 2,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "printWidth": 100,
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 5.1.0
+* Fix for `preventDefaultTouchmoveEvent` in safari [issue #127](https://github.com/dogfessional/react-swipeable/issues/127) and [PR #131](https://github.com/dogfessional/react-swipeable/pull/131)
+  * Thank you [@JiiB](https://github.com/JiiB) and [@bhj](https://github.com/bhj)!
+  * use `ref` callback for both `<Swipeable>` and `useSwipeable` to attach all touch event handlers
+    * `useSwipeable`'s returned `handlers` now contains a ref callback
+    * Please see disscusion and comments in both [#127](https://github.com/dogfessional/react-swipeable/issues/127) and [#131](https://github.com/dogfessional/react-swipeable/issues/127) for more details and info.
+      * fix avoids the `passive: true` issue from chrome document event listeners
+      * fix avoids bug on safari where the `touchmove` event listener needs to be attached before a `touchstart` in order to be able to call `e.preventDefault`
+* removed `touchHandlerOption` prop
+  * fix above deprecates this prop
+
 # 5.0.0
 * Introduce react hook, `useSwipeable`
 * Core rewrite to simplify api and trim down bundled size

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import { useSwipeable, Swipeable } from 'react-swipeable'
 const handlers = useSwipeable({ onSwiped: (eventData) => eventHandler, ...config })
 return (<div {...handlers}> You can swipe here </div>)
 ```
-Hook use requires **react >= 16.8.0**.
+Spread `handlers` onto the element you wish to track swipes inside of. [Details below](#hook-details).
 
 #### Component
 ```jsx
@@ -81,10 +81,6 @@ All Event Handlers are called with the below event data.
   trackTouch: true,                      // track touch input
   trackMouse: false,                     // track mouse input
   rotationAngle: 0,                      // set a rotation angle
-
-  touchHandlerOption: {         // overwrite touch handler 3rd argument
-    passive: true|false         // defaults opposite of preventDefaultTouchmoveEvent *See Details*
-  },
 }
 ```
 
@@ -92,12 +88,18 @@ All Event Handlers are called with the below event data.
 
 ```
 {
-  nodeName: 'div',      // internal component dom node
-  innerRef              // access internal component dom node
+  nodeName: 'div',    // internally rendered component dom node
+  innerRef            // callback ref for internal component dom node
 }
 ```
 
 **None of the props/config options are required.**
+
+### Hook details
+- Hook use requires **react >= 16.8.0**
+- The props contained in `handlers` are currently `ref` and `onMouseDown`
+  - Please spread `handlers` as the props contained in it could change as react improves event listening capabilities
+    - See [#127](https://github.com/dogfessional/react-swipeable/issues/127) for some more context
 
 ### preventDefaultTouchmoveEvent Details
 
@@ -106,16 +108,11 @@ All Event Handlers are called with the below event data.
   * `preventDefaultTouchmoveEvent: true`
   * `trackTouch: true`
   * the users current swipe has an associated `onSwiping` or `onSwiped` handler/prop
-* if `preventDefaultTouchmoveEvent: true` then `touchHandlerOption` defaults to `{ passive: false }`
-* if `preventDefaultTouchmoveEvent: false` then `touchHandlerOption` defaults to `{ passive: true }`
 
 Example:
    * If a user is swiping right with `<Swipable onSwipedRight={this.userSwipedRight} preventDefaultTouchmoveEvent={true} >` then `e.preventDefault()` will be called, but if the user was swiping left then `e.preventDefault()` would **not** be called.
 
 Please experiment with the [example](http://dogfessional.github.io/react-swipeable/) to test `preventDefaultTouchmoveEvent`.
-
-#### Older browser support
-If you need to support older browsers that do not have support for `{passive: false}` `addEventListener` 3rd argument, we recommend using [detect-passive-events](https://www.npmjs.com/package/detect-passive-events) package to determine the `touchHandlerOption` prop value.
 
 
 ## Development

--- a/examples/app/FeatureTestConsole.js
+++ b/examples/app/FeatureTestConsole.js
@@ -27,6 +27,9 @@ const initialStateSwipeable = {
   rotationAngle: 0,
 };
 const initialStateApplied = {
+  showHook: true,
+  showComponent: true,
+  showOnSwipeds: false,
   onSwipingApplied: true,
   onSwipedApplied: true,
   onSwipedLeftApplied: true,
@@ -100,6 +103,9 @@ export default class Main extends Component {
       swipingDirection,
       swipedDirection,
       delta,
+      showHook,
+      showComponent,
+      showOnSwipeds,
       onSwipingApplied,
       onSwipedApplied,
       persistEvent,
@@ -129,7 +135,7 @@ export default class Main extends Component {
       <div className="row" id="FeatureTestConsole">
         <div className="small-12 column">
           <h5><strong>Test react-swipeable features.</strong></h5>
-          <Swipeable
+          {showComponent && <Swipeable
             {...boundSwipes}
             {...swipeableDirProps}
             delta={deltaNum}
@@ -137,15 +143,15 @@ export default class Main extends Component {
             trackTouch={trackTouch}
             trackMouse={trackMouse}
             rotationAngle={rotationAngleNum}
-            className="callout"
+            className="callout classComponent"
             style={swipeableStyle}>
               <div onTouchStart={()=>this.resetState()}>
                 <h5>Component - Swipe inside here to test</h5>
                 <p>See output below and check the console for 'onSwiping' and 'onSwiped' callback output(open dev tools)</p>
                 <span>You can also 'toggle' the swip(ed/ing) props being applied to this container below.</span>
               </div>
-          </Swipeable>
-          <SwipeableHook
+          </Swipeable>}
+          {showHook && <SwipeableHook
             {...boundSwipes}
             {...swipeableDirProps}
             delta={deltaNum}
@@ -153,14 +159,14 @@ export default class Main extends Component {
             trackTouch={trackTouch}
             trackMouse={trackMouse}
             rotationAngle={rotationAngleNum}
-            className="callout"
+            className="callout hookComponent"
             style={swipeableStyle}>
               <div onTouchStart={()=>this.resetState()}>
                 <h5>Hook - Swipe inside here to test</h5>
                 <p>See output below and check the console for 'onSwiping' and 'onSwiped' callback output(open dev tools)</p>
                 <span>You can also 'toggle' the swip(ed/ing) props being applied to this container below.</span>
               </div>
-          </SwipeableHook>
+          </SwipeableHook>}
           <table>
             <thead>
               <tr><th>Applied?</th><th>Action</th><th>Output</th></tr>
@@ -185,9 +191,26 @@ export default class Main extends Component {
                 <td>onSwiping Direction</td><td>{swipingDirection}</td>
               </tr>
               <tr>
-                <td className="text-center"><a href="#appliedDirs">↓&nbsp;Below&nbsp;↓</a></td>
+                <td className="text-center">
+                  <a href="#" onClick={(e)=>(e.preventDefault(),this.updateValue('showOnSwipeds', !showOnSwipeds))}>
+                    {showOnSwipeds ? '↑ Hide ↑' : '↓ Show ↓'}
+                  </a>
+                </td>
                 <td>onSwiped Direction</td><td>{swipedDirection}</td>
               </tr>
+              {showOnSwipeds && <tr>
+                <td className="text-center" colSpan="3">
+                  <table id="appliedDirs">
+                    <thead>
+                      <tr><th colSpan="2" className="text-center">onSwiped</th></tr>
+                      <tr><th>Applied?</th><th>Direction</th></tr>
+                    </thead>
+                    <tbody>
+                      {DIRECTIONS.map(this._renderAppliedDirRow.bind(this))}
+                    </tbody>
+                  </table>
+                </td>
+              </tr>}
               <tr>
                 <td colSpan="2" className="text-center">delta:</td>
                 <td>
@@ -228,15 +251,24 @@ export default class Main extends Component {
                     onChange={(e)=>this.updateValue('persistEvent', e.target.checked)}/>
                 </td>
               </tr>
-            </tbody>
-          </table>
-          <table id="appliedDirs">
-            <thead>
-              <tr><th colSpan="2" className="text-center">onSwiped</th></tr>
-              <tr><th>Applied?</th><th>Direction</th></tr>
-            </thead>
-            <tbody>
-              {DIRECTIONS.map(this._renderAppliedDirRow.bind(this))}
+              <tr>
+                <td colSpan="2" className="text-center">Show Hook Example:</td>
+                <td style={{textAlign: "center"}}>
+                  <input style={{margin: "0px"}}
+                    type="checkbox"
+                    checked={showHook}
+                    onChange={(e)=>this.updateValue('showHook', e.target.checked)}/>
+                </td>
+              </tr>
+              <tr>
+                <td colSpan="2" className="text-center">Show Component Example:</td>
+                <td style={{textAlign: "center"}}>
+                  <input style={{margin: "0px"}}
+                    type="checkbox"
+                    checked={showComponent}
+                    onChange={(e)=>this.updateValue('showComponent', e.target.checked)}/>
+                </td>
+              </tr>
             </tbody>
           </table>
           <table style={{width: "100%"}}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable",
-  "version": "5.0.1",
+  "version": "5.1.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable",
-  "version": "5.0.1",
+  "version": "5.1.0-alpha.1",
   "description": "Swipe and touch handlers for react",
   "main": "./lib/index.js",
   "module": "es/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,13 +3,7 @@ import pkg from './package.json'
 
 export default {
   input: './src/index.js',
-  output: [
-    { file: `${pkg.main}`, format: 'cjs' },
-    { file: `${pkg.module}`, format: 'es' }
-  ],
-  external: [
-    ...Object.keys(pkg.dependencies || {}),
-    ...Object.keys(pkg.peerDependencies || {})
-  ],
+  output: [{ file: `${pkg.main}`, format: 'cjs' }, { file: `${pkg.module}`, format: 'es' }],
+  external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
   plugins: [babel()]
 }

--- a/src/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/__tests__/__snapshots__/index.spec.js.snap
@@ -1,62 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Swipeable allows touchHandlerOption overwrite: verify touchHandlerOption overwrite 1`] = `
-Array [
-  Array [
-    "touchmove",
-    [Function],
-    Object {
-      "capture": true,
-    },
-  ],
-  Array [
-    "touchend",
-    [Function],
-    Object {
-      "capture": true,
-    },
-  ],
-]
-`;
-
-exports[`Swipeable calls preventDefault when swiping in direction that has a callback: verify touchHandlerOption passive is false 1`] = `
-Array [
-  Array [
-    "touchmove",
-    [Function],
-    Object {
-      "passive": false,
-    },
-  ],
-  Array [
-    "touchend",
-    [Function],
-    Object {
-      "passive": false,
-    },
-  ],
-]
-`;
-
-exports[`Swipeable does not call preventDefault when false: verify touchHandlerOption passive is true 1`] = `
-Array [
-  Array [
-    "touchmove",
-    [Function],
-    Object {
-      "passive": true,
-    },
-  ],
-  Array [
-    "touchend",
-    [Function],
-    Object {
-      "passive": true,
-    },
-  ],
-]
-`;
-
 exports[`Swipeable handles mouse events with trackMouse prop and fires correct props: Swipeable onSwiped trackMouse 1`] = `
 Array [
   Array [
@@ -246,63 +189,6 @@ Array [
         ],
       },
       "velocity": 1.8903591679142773,
-    },
-  ],
-]
-`;
-
-exports[`useSwipeable allows touchHandlerOption overwrite: verify touchHandlerOption overwrite 1`] = `
-Array [
-  Array [
-    "touchmove",
-    [Function],
-    Object {
-      "capture": true,
-    },
-  ],
-  Array [
-    "touchend",
-    [Function],
-    Object {
-      "capture": true,
-    },
-  ],
-]
-`;
-
-exports[`useSwipeable calls preventDefault when swiping in direction that has a callback: verify touchHandlerOption passive is false 1`] = `
-Array [
-  Array [
-    "touchmove",
-    [Function],
-    Object {
-      "passive": false,
-    },
-  ],
-  Array [
-    "touchend",
-    [Function],
-    Object {
-      "passive": false,
-    },
-  ],
-]
-`;
-
-exports[`useSwipeable does not call preventDefault when false: verify touchHandlerOption passive is true 1`] = `
-Array [
-  Array [
-    "touchmove",
-    [Function],
-    Object {
-      "passive": true,
-    },
-  ],
-  Array [
-    "touchend",
-    [Function],
-    Object {
-      "passive": true,
     },
   ],
 ]

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -3,10 +3,7 @@ import React from 'react'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { Swipeable, useSwipeable, LEFT, RIGHT, UP, DOWN } from '../index'
-import {
-  createTouchEventObject as cte,
-  createMouseEventObject as cme
-} from './helpers/events'
+import { createTouchEventObject as cte, createMouseEventObject as cme } from './helpers/events'
 
 const { mount } = Enzyme
 
@@ -15,10 +12,10 @@ Enzyme.configure({ adapter: new Adapter() })
 const DIRECTIONS = [LEFT, RIGHT, UP, DOWN]
 
 function getMockedSwipeFunctions() {
-  return DIRECTIONS.reduce(
-    (acc, dir) => ({ ...acc, [`onSwiped${dir}`]: jest.fn() }),
-    { onSwiping: jest.fn(), onSwiped: jest.fn() }
-  )
+  return DIRECTIONS.reduce((acc, dir) => ({ ...acc, [`onSwiped${dir}`]: jest.fn() }), {
+    onSwiping: jest.fn(),
+    onSwiped: jest.fn()
+  })
 }
 
 function expectSwipingDir(fns, dir) {
@@ -43,36 +40,50 @@ function mockListenerSetup(el) {
   // idea from - https://github.com/airbnb/enzyme/issues/426#issuecomment-228601631
   const eventListenerMap = {}
   el.addEventListener = jest.fn((event, cb) => {
-    // eslint-disable-line no-param-reassign
     eventListenerMap[event] = cb
   })
   el.removeEventListener = jest.fn((event, cb) => {
-    // eslint-disable-line no-param-reassign
     if (eventListenerMap[event] === cb) delete eventListenerMap[event]
   })
   return eventListenerMap
 }
 
+/*
+ * Wrapping component for the hook.
+ */
 function SwipeableUsingHook(props) {
   const eventHandlers = useSwipeable(props)
-  return <div {...eventHandlers}>{props.children}</div> // eslint-disable-line
+  // Use innerRef prop to access the mounted div for testing.
+  const ref = el => (props.innerRef && props.innerRef(el), eventHandlers.ref(el)) // eslint-disable-line
+  return (
+    <div {...eventHandlers} ref={ref}>
+      {props.children}
+    </div>
+  )
 }
 
 function setupGetMountedComponent(type) {
   return props => {
+    let wrapper
+    let eventListenerMap
+    const innerRef = el => {
+      // don't re-assign eventlistener map
+      if (!eventListenerMap) eventListenerMap = mockListenerSetup(el)
+    }
     if (type === 'Swipeable') {
-      return mount(
-        <Swipeable {...props}>
+      wrapper = mount(
+        <Swipeable {...props} innerRef={innerRef}>
           <span>Touch Here</span>
         </Swipeable>
       )
     } else if (type === 'useSwipeable') {
-      return mount(
-        <SwipeableUsingHook {...props}>
+      wrapper = mount(
+        <SwipeableUsingHook {...props} innerRef={innerRef}>
           <span>Touch Here</span>
         </SwipeableUsingHook>
       )
     }
+    return { eventListenerMap, wrapper }
   }
 }
 
@@ -80,7 +91,7 @@ function setupGetMountedComponent(type) {
   describe(`${type}`, () => {
     let origAddEventListener
     let origRemoveEventListener
-    let eventListenerMap
+    let eventListenerMapDocument
     const getMountedComponent = setupGetMountedComponent(type)
     beforeAll(() => {
       origAddEventListener = document.addEventListener
@@ -89,7 +100,7 @@ function setupGetMountedComponent(type) {
     beforeEach(() => {
       // track eventListener adds to trigger later
       // idea from - https://github.com/airbnb/enzyme/issues/426#issuecomment-228601631
-      eventListenerMap = mockListenerSetup(document)
+      eventListenerMapDocument = mockListenerSetup(document)
     })
     afterAll(() => {
       document.eventListener = origAddEventListener
@@ -98,47 +109,29 @@ function setupGetMountedComponent(type) {
 
     it('handles touch events and fires correct props', () => {
       const swipeFuncs = getMockedSwipeFunctions()
-      const wrapper = getMountedComponent({ ...swipeFuncs })
+      const { eventListenerMap } = getMountedComponent({ ...swipeFuncs })
 
-      const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'touchStart',
-        cte({ x: 100, y: 100, timeStamp: 8077.299999946263 })
-      )
+      eventListenerMap.touchstart(cte({ x: 100, y: 100, timeStamp: 8077.299999946263 }))
 
-      eventListenerMap.touchmove(
-        cte({ x: 100, y: 125, timeStamp: 8100.999999966007 })
-      )
-      eventListenerMap.touchmove(
-        cte({ x: 100, y: 150, timeStamp: 8116.899999964517 })
-      )
-      eventListenerMap.touchmove(
-        cte({ x: 100, y: 175, timeStamp: 8122.799999953713 })
-      )
-      eventListenerMap.touchmove(
-        cte({ x: 100, y: 200, timeStamp: 8130.199999955433 })
-      )
+      eventListenerMap.touchmove(cte({ x: 100, y: 125, timeStamp: 8100.999999966007 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 150, timeStamp: 8116.899999964517 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 175, timeStamp: 8122.799999953713 }))
+      eventListenerMap.touchmove(cte({ x: 100, y: 200, timeStamp: 8130.199999955433 }))
       eventListenerMap.touchend(cte({}))
 
       expect(swipeFuncs.onSwipedDown).toHaveBeenCalled()
       expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedRight).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwiped.mock.calls).toMatchSnapshot(
-        `${type} onSwiped trackTouch`
-      )
-      expect(swipeFuncs.onSwiping.mock.calls).toMatchSnapshot(
-        `${type} onSwiping trackTouch`
-      )
-
-      wrapper.unmount()
+      expect(swipeFuncs.onSwiped.mock.calls).toMatchSnapshot(`${type} onSwiped trackTouch`)
+      expect(swipeFuncs.onSwiping.mock.calls).toMatchSnapshot(`${type} onSwiping trackTouch`)
     })
 
     it('handles mouse events with trackMouse prop and fires correct props', () => {
       const swipeFuncs = getMockedSwipeFunctions()
       const preventDefault = jest.fn()
       const e = { preventDefault }
-      const wrapper = getMountedComponent({
+      const { wrapper } = getMountedComponent({
         ...swipeFuncs,
         trackMouse: true,
         trackTouch: false,
@@ -146,51 +139,41 @@ function setupGetMountedComponent(type) {
       })
 
       const touchHere = wrapper.find('span')
-      touchHere.simulate(
-        'mouseDown',
-        cme({ x: 100, y: 100, timeStamp: 1374809.499999974 })
-      )
+      touchHere.simulate('mouseDown', cme({ x: 100, y: 100, timeStamp: 1374809.499999974 }))
 
-      eventListenerMap.mousemove(
+      eventListenerMapDocument.mousemove(
         cme({ x: 125, y: 100, timeStamp: 1374825.199999963, ...e })
       )
-      eventListenerMap.mousemove(
+      eventListenerMapDocument.mousemove(
         cme({ x: 150, y: 100, timeStamp: 1374841.3999999757, ...e })
       )
-      eventListenerMap.mousemove(
+      eventListenerMapDocument.mousemove(
         cme({ x: 175, y: 100, timeStamp: 1374857.399999979, ...e })
       )
-      eventListenerMap.mousemove(
+      eventListenerMapDocument.mousemove(
         cme({ x: 200, y: 100, timeStamp: 1374873.499999987, ...e })
       )
-      eventListenerMap.mouseup({})
+      eventListenerMapDocument.mouseup({})
 
       expect(preventDefault).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedRight).toHaveBeenCalled()
       expect(swipeFuncs.onSwipedUp).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedDown).not.toHaveBeenCalled()
       expect(swipeFuncs.onSwipedLeft).not.toHaveBeenCalled()
-      expect(swipeFuncs.onSwiped.mock.calls).toMatchSnapshot(
-        `${type} onSwiped trackMouse`
-      )
-      expect(swipeFuncs.onSwiping.mock.calls).toMatchSnapshot(
-        `${type} onSwiping trackMouse`
-      )
-
-      wrapper.unmount()
+      expect(swipeFuncs.onSwiped.mock.calls).toMatchSnapshot(`${type} onSwiped trackMouse`)
+      expect(swipeFuncs.onSwiping.mock.calls).toMatchSnapshot(`${type} onSwiping trackMouse`)
     })
 
     it('calls preventDefault when swiping in direction that has a callback', () => {
       const onSwipedDown = jest.fn()
       const preventDefault = jest.fn()
       const e = { preventDefault }
-      const wrapper = getMountedComponent({
+      const { eventListenerMap } = getMountedComponent({
         onSwipedDown,
         preventDefaultTouchmoveEvent: true
       })
 
-      const touchHere = wrapper.find('span')
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100, ...e }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100, ...e }))
 
       eventListenerMap.touchmove(cte({ x: 100, y: 125, ...e }))
       eventListenerMap.touchmove(cte({ x: 100, y: 150, ...e }))
@@ -201,22 +184,15 @@ function setupGetMountedComponent(type) {
       expect(onSwipedDown).toHaveBeenCalled()
 
       expect(preventDefault).toHaveBeenCalledTimes(4)
-
-      expect(document.addEventListener.mock.calls).toMatchSnapshot(
-        'verify touchHandlerOption passive is false'
-      )
-
-      wrapper.unmount()
     })
 
     it('does not call preventDefault when false', () => {
       const onSwipedUp = jest.fn()
       const preventDefault = jest.fn()
       const e = { preventDefault }
-      const wrapper = getMountedComponent({ onSwipedUp })
+      const { eventListenerMap } = getMountedComponent({ onSwipedUp })
 
-      const touchHere = wrapper.find('span')
-      touchHere.simulate('touchstart', cte({ x: 100, y: 100, ...e }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100, ...e }))
 
       eventListenerMap.touchmove(cte({ x: 100, y: 75, ...e }))
       eventListenerMap.touchmove(cte({ x: 100, y: 50, ...e }))
@@ -227,38 +203,17 @@ function setupGetMountedComponent(type) {
       expect(onSwipedUp).toHaveBeenCalled()
 
       expect(preventDefault).not.toHaveBeenCalled()
-      expect(document.addEventListener.mock.calls).toMatchSnapshot(
-        'verify touchHandlerOption passive is true'
-      )
-      wrapper.unmount()
-    })
-
-    it('allows touchHandlerOption overwrite', () => {
-      const touchHandlerOption = { capture: true }
-      const wrapper = getMountedComponent({ touchHandlerOption })
-
-      const touchHere = wrapper.find('span')
-      touchHere.simulate('touchstart', cte({ x: 100, y: 100 }))
-
-      eventListenerMap.touchmove(cte({ x: 100, y: 75 }))
-      eventListenerMap.touchend({})
-
-      expect(document.addEventListener.mock.calls).toMatchSnapshot(
-        'verify touchHandlerOption overwrite'
-      )
-      wrapper.unmount()
     })
 
     it('calls preventDefault when onSwiping is present', () => {
       const onSwiping = jest.fn()
       const preventDefault = jest.fn()
-      const wrapper = getMountedComponent({
+      const { eventListenerMap } = getMountedComponent({
         onSwiping,
         preventDefaultTouchmoveEvent: true
       })
 
-      const touchHere = wrapper.find('span')
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100, preventDefault }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100, preventDefault }))
 
       eventListenerMap.touchmove(cte({ x: 100, y: 50, preventDefault }))
       eventListenerMap.touchmove(cte({ x: 100, y: 5, preventDefault }))
@@ -267,19 +222,17 @@ function setupGetMountedComponent(type) {
       expect(onSwiping).toHaveBeenCalled()
 
       expect(preventDefault).toHaveBeenCalled()
-      wrapper.unmount()
     })
 
     it('calls preventDefault when onSwiped is present', () => {
       const onSwiped = jest.fn()
       const preventDefault = jest.fn()
-      const wrapper = getMountedComponent({
+      const { eventListenerMap } = getMountedComponent({
         onSwiped,
         preventDefaultTouchmoveEvent: true
       })
 
-      const touchHere = wrapper.find('span')
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100, preventDefault }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100, preventDefault }))
 
       eventListenerMap.touchmove(cte({ x: 100, y: 50, preventDefault }))
       eventListenerMap.touchmove(cte({ x: 100, y: 5, preventDefault }))
@@ -288,14 +241,13 @@ function setupGetMountedComponent(type) {
       expect(onSwiped).toHaveBeenCalled()
 
       expect(preventDefault).toHaveBeenCalled()
-      wrapper.unmount()
     })
 
     it('does not re-check delta when swiping already in progress', () => {
       const onSwiping = jest.fn()
       const onSwipedRight = jest.fn()
       const onSwipedLeft = jest.fn()
-      const wrapper = getMountedComponent({
+      const { eventListenerMap } = getMountedComponent({
         onSwiping,
         onSwipedRight,
         onSwipedLeft,
@@ -303,8 +255,7 @@ function setupGetMountedComponent(type) {
         delta: 40
       })
 
-      const touchHere = wrapper.find('span')
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
 
       eventListenerMap.touchmove(cte({ x: 145, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 80, y: 100 }))
@@ -315,20 +266,18 @@ function setupGetMountedComponent(type) {
       expect(onSwiping.mock.calls[1][0].dir).toBe(LEFT)
       expect(onSwipedLeft).toHaveBeenCalledTimes(1)
       expect(onSwipedRight).not.toHaveBeenCalled()
-      wrapper.unmount()
     })
 
     it('Handle Rotation by 90 degree', () => {
       const swipeFuncsRight = getMockedSwipeFunctions()
 
-      const wrapper = getMountedComponent({
+      const { eventListenerMap, wrapper } = getMountedComponent({
         ...swipeFuncsRight,
         rotationAngle: 90
       })
-      const touchHere = wrapper.find('span')
 
       // check right
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
@@ -337,7 +286,7 @@ function setupGetMountedComponent(type) {
       // check left
       const swipeFuncsLeft = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsLeft, rotationAngle: 90 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 75 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 50 }))
       eventListenerMap.touchend({})
@@ -346,7 +295,7 @@ function setupGetMountedComponent(type) {
       // check up
       const swipeFuncsUp = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsUp, rotationAngle: 90 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 125, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 150, y: 100 }))
       eventListenerMap.touchend({})
@@ -355,26 +304,23 @@ function setupGetMountedComponent(type) {
       // check down
       const swipeFuncsDown = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsDown, rotationAngle: 90 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 75, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 50, y: 100 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsDown, DOWN)
-
-      wrapper.unmount()
     })
 
     it('Handle "odd" rotations', () => {
       const swipeFuncsNegativeRotation = getMockedSwipeFunctions()
 
-      const wrapper = getMountedComponent({
+      const { eventListenerMap, wrapper } = getMountedComponent({
         ...swipeFuncsNegativeRotation,
         rotationAngle: -90
       })
-      const touchHere = wrapper.find('span')
 
       // check -90
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
@@ -383,23 +329,20 @@ function setupGetMountedComponent(type) {
       // check 360 + 270
       const swipeFuncsLargeRotation = getMockedSwipeFunctions()
       wrapper.setProps({ ...swipeFuncsLargeRotation, rotationAngle: 360 + 270 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
       expectSwipeFuncsDir(swipeFuncsLargeRotation, 'Left')
-
-      wrapper.unmount()
     })
 
     it('Handle Rotation that changes so keep the direction the same', () => {
       const swipeFuncs = getMockedSwipeFunctions()
 
-      const wrapper = getMountedComponent({ ...swipeFuncs })
-      const touchHere = wrapper.find('span')
+      const { eventListenerMap, wrapper } = getMountedComponent({ ...swipeFuncs })
 
       // check 0
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 125, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 150, y: 100 }))
       eventListenerMap.touchend({})
@@ -408,7 +351,7 @@ function setupGetMountedComponent(type) {
 
       // check 90
       wrapper.setProps({ rotationAngle: 90 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 125 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 150 }))
       eventListenerMap.touchend({})
@@ -417,7 +360,7 @@ function setupGetMountedComponent(type) {
 
       // check 180
       wrapper.setProps({ rotationAngle: 180 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 75, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 50, y: 100 }))
       eventListenerMap.touchend({})
@@ -426,7 +369,7 @@ function setupGetMountedComponent(type) {
 
       // check 270
       wrapper.setProps({ rotationAngle: 270 })
-      touchHere.simulate('touchStart', cte({ x: 100, y: 100 }))
+      eventListenerMap.touchstart(cte({ x: 100, y: 100 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 75 }))
       eventListenerMap.touchmove(cte({ x: 100, y: 50 }))
       eventListenerMap.touchend({})
@@ -437,8 +380,6 @@ function setupGetMountedComponent(type) {
       ;[LEFT, UP, DOWN].forEach(dir => {
         expect(swipeFuncs[`onSwiped${dir}`]).not.toHaveBeenCalled()
       })
-
-      wrapper.unmount()
     })
   })
 })
@@ -460,15 +401,17 @@ describe('Swipeable Specific', () => {
       static displayName = 'WrapperComp'
       constructor(props) {
         super(props)
-        this.testRef = React.createRef()
+      }
+      assignRef = el => {
+        this.testRef = el
       }
       render() {
-        return <Swipeable innerRef={this.testRef} />
+        return <Swipeable innerRef={this.assignRef} />
       }
     }
     const wrapper = mount(<WrapperComp />)
     const swipeableDiv = wrapper.find('div').instance()
-    expect(wrapper.instance().testRef.current).toBe(swipeableDiv)
+    expect(wrapper.instance().testRef).toBe(swipeableDiv)
     wrapper.unmount()
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -40,10 +40,8 @@ function getDirection(absX, absY, deltaX, deltaY) {
 function rotateXYByAngle(pos, angle) {
   if (angle === 0) return pos
   const angleInRadians = (Math.PI / 180) * angle
-  const x =
-    pos[0] * Math.cos(angleInRadians) + pos[1] * Math.sin(angleInRadians)
-  const y =
-    pos[1] * Math.cos(angleInRadians) - pos[0] * Math.sin(angleInRadians)
+  const x = pos[0] * Math.cos(angleInRadians) + pos[1] * Math.sin(angleInRadians)
+  const y = pos[1] * Math.cos(angleInRadians) - pos[0] * Math.sin(angleInRadians)
   return [x, y]
 }
 
@@ -65,18 +63,11 @@ function getHandlers(set, props) {
 
   const onMove = event => {
     set(state => {
-      if (
-        !state.xy[0] ||
-        !state.xy[1] ||
-        (event.touches && event.touches.length > 1)
-      ) {
+      if (!state.xy[0] || !state.xy[1] || (event.touches && event.touches.length > 1)) {
         return state
       }
       const { clientX, clientY } = event.touches ? event.touches[0] : event
-      const [x, y] = rotateXYByAngle(
-        [clientX, clientY],
-        state.props.rotationAngle
-      )
+      const [x, y] = rotateXYByAngle([clientX, clientY], state.props.rotationAngle)
       const deltaX = state.xy[0] - x
       const deltaY = state.xy[1] - y
       const absX = Math.abs(deltaX)
@@ -85,8 +76,7 @@ function getHandlers(set, props) {
       const velocity = Math.sqrt(absX * absX + absY * absY) / (time || 1)
 
       // if swipe is under delta and we have not started to track a swipe: skip update
-      if (absX < props.delta && absY < props.delta && !state.swiping)
-        return state
+      if (absX < props.delta && absY < props.delta && !state.swiping) return state
 
       const dir = getDirection(absX, absY, deltaX, deltaY)
       const eventData = { event, absX, absY, deltaX, deltaY, velocity, dir }
@@ -96,19 +86,11 @@ function getHandlers(set, props) {
       // track if a swipe is cancelable(handler for swiping or swiped(dir) exists)
       // so we can call preventDefault if needed
       let cancelablePageSwipe = false
-      if (
-        state.props.onSwiping ||
-        state.props.onSwiped ||
-        state.props[`onSwiped${dir}`]
-      ) {
+      if (state.props.onSwiping || state.props.onSwiped || state.props[`onSwiped${dir}`]) {
         cancelablePageSwipe = true
       }
 
-      if (
-        cancelablePageSwipe &&
-        state.props.preventDefaultTouchmoveEvent &&
-        state.props.trackTouch
-      )
+      if (cancelablePageSwipe && state.props.preventDefaultTouchmoveEvent && state.props.trackTouch)
         event.preventDefault()
 
       return { ...state, lastEventData: eventData, swiping: true }
@@ -205,10 +187,7 @@ export class Swipeable extends React.PureComponent {
     nodeName: PropTypes.string,
     trackMouse: PropTypes.bool,
     trackTouch: PropTypes.bool,
-    innerRef: PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.shape({ current: PropTypes.any })
-    ]),
+    innerRef: PropTypes.func,
     rotationAngle: PropTypes.number
   }
 
@@ -221,20 +200,9 @@ export class Swipeable extends React.PureComponent {
   }
 
   render() {
-    const {
-      className,
-      style,
-      nodeName = 'div',
-      innerRef,
-      children,
-      ...rest
-    } = this.props
+    const { className, style, nodeName = 'div', innerRef, children, ...rest } = this.props
     const handlers = getHandlers(this._set, rest)
     const ref = innerRef ? el => (innerRef(el), handlers.ref(el)) : handlers.ref
-    return React.createElement(
-      nodeName,
-      { ...handlers, className, style, ref },
-      children
-    )
+    return React.createElement(nodeName, { ...handlers, className, style, ref }, children)
   }
 }


### PR DESCRIPTION
- fixes #127 
- supersedes #130 
- published as `react-swipeable@5.1.0-alpha.1`

After more digging and exploration this mimics `v4` by using a `ref` callback to then set the `touchstart` and `touchmove` event listeners before any touch/swipe starts being tracked.

This solution is ultimately a work around for these issues:
- the event delegation that react uses is a problem for ios **and** chrome by not having the `{ passive: false }` option set, which is needed to call `preventDefault`
- ios requires that the `touchmove` be attached **before** a touch event starts
  - https://github.com/Shopify/draggable/pull/200
- `passive` option defaults to `false` when attaching the touch listeners to the swiping container via the `ref`, chrome/firefox and possibly ios
  - if you attach a touch listeners to `document` the `passive` option defaults to `true`
  - https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners

TODO:
- [x] update tests
- [x] update docs
  - 🎉 clean up all `touchHandlerOption` and `passive` event listener notes
  - document how `useSwipeable`'s returned `handlers` have a callback `ref` now
    - since it was documented to spread this onto the node this should be backwards compatible and only a minor bump
  - document how `innerRef` prop for `<Swipeable />` can **only** be a callback
    - exp: `(el) => this.swipeable = el;`
- [x] update changelog