### PR TITLE
Fix touch event cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable",
-  "version": "5.1.0-alpha.1",
+  "version": "5.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable",
-  "version": "5.1.0-alpha.1",
+  "version": "5.1.0-alpha.2",
   "description": "Swipe and touch handlers for react",
   "main": "./lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "size-limit": [
     {
-      "limit": "1.8 KB",
+      "limit": "1.875 KB",
       "path": "es/index.js"
     }
   ],


### PR DESCRIPTION
right before i was about to release `5.1.0` found that the #131 added a bug where touch events were not being "cleaned up" if `trackTouch` was toggled. This pr "cleans up" the touch event listeners.

published as `react-swipeable@5.1.0-alpha.2`

- test added that verifies that touch event listeners are removed
- have to bump the `size-limit` too, just a bit with room to breath