### PR TITLE
Fix `preventDefaultTouchmoveEvent` and other props not propagating updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,12 +217,14 @@ export class Swipeable extends React.PureComponent {
   constructor(props) {
     super(props)
     this._state = { ...initialState, type: 'class' }
+    this._handlerProps = {}
     this._set = cb => (this._state = cb(this._state))
   }
 
   render() {
     const { className, style, nodeName = 'div', innerRef, children, ...rest } = this.props
-    const handlers = getHandlers(this._set, rest)
+    Object.assign(this._handlerProps, rest)
+    const handlers = getHandlers(this._set, this._handlerProps)
     const ref = innerRef ? el => (innerRef(el), handlers.ref(el)) : handlers.ref
     return React.createElement(nodeName, { ...handlers, className, style, ref }, children)
   }


### PR DESCRIPTION
Currently different `props` objects are sent to `getHandlers` on each `render`.

In theory this is fine, but because of the way that `getHandlers` sets up event listeners (such as `onMove` listeners), the `state.props` object that gets used by these listeners is actually fixed as an older value.

In practice, what this means, is that if props like `preventDefaultTouchmoveEvent` change on the fly, then the value of `state.props.preventDefaultTouchmoveEvent` in the `onMove` callback does not get the new value, and instead keeps the initial value sent through.

This PR sets up an explicit `props` object to be passed through - so that the object reference is the same everywhere, so that the callback handlers get the up to date prop values.