### PR TITLE
Fix error touchmove event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ function getHandlers(set, handlerProps) {
         cancelablePageSwipe = true
       }
 
-      if (cancelablePageSwipe && props.preventDefaultTouchmoveEvent && props.trackTouch)
+      if (cancelablePageSwipe && props.preventDefaultTouchmoveEvent && props.trackTouch && event.cancelable)
         event.preventDefault()
 
       return { ...state, lastEventData: eventData, swiping: true }


### PR DESCRIPTION
Fix to issue #128 

Added ```event.cancelable``` validation in order to avoid error:
 ```Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.```

