### PR TITLE
Pass down all props

### DIFF
--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -527,4 +527,10 @@ describe('Swipeable Specific', () => {
     expect(wrapper.instance().testRef).toBe(swipeableDiv)
     wrapper.unmount()
   })
+
+  it('passes down props', () => {
+    const wrapper = mount(<Swipeable data-testid="custom-prop" />)
+    expect(wrapper.find('div').prop('data-testid')).toBe('custom-prop')
+    wrapper.unmount()
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -240,10 +240,18 @@ export class Swipeable extends React.PureComponent {
   }
 
   render() {
-    const { className, style, nodeName = 'div', innerRef, children, trackMouse } = this.props
+    const {
+      className,
+      style,
+      nodeName = 'div',
+      innerRef,
+      children,
+      trackMouse,
+      ...rest
+    } = this.props
     const [handlers, attachTouch] = getHandlers(this._set, { trackMouse })
     this.transientState = updateTransientState(this.transientState, this.props, attachTouch)
     const ref = innerRef ? el => (innerRef(el), handlers.ref(el)) : handlers.ref
-    return React.createElement(nodeName, { ...handlers, className, style, ref }, children)
+    return React.createElement(nodeName, { ...rest, ...handlers, className, style, ref }, children)
   }
 }


### PR DESCRIPTION
Prior to version 5 all additional props besides the ones used by `react-swipeable` were passed down. It's not listed as breaking change, so I'm not sure if was removed on purpose.
I assume it was not, and since  `Swipeable` will still render an actual `div` it makes sense to pass all props down to it.

PS: Breaking the max build size wit it 🎉 :)