### PR TITLE
add first to eventData

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ All Event Handlers are called with the below event data.
 {
   event,          // source event
   initial,        // initial swipe [x,y]
+  first,          // true for first event
   deltaX,         // x offset (initial.x - current.x)
   deltaY,         // y offset (initial.y - current.y)
   absX,           // absolute deltaX

--- a/src/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/__tests__/__snapshots__/index.spec.js.snap
@@ -10,6 +10,7 @@ Array [
       "deltaY": 0,
       "dir": "Right",
       "event": Object {},
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -35,6 +36,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374825.199999963,
       },
+      "first": true,
       "initial": Array [
         100,
         100,
@@ -55,6 +57,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374841.3999999757,
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -75,6 +78,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374857.399999979,
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -95,6 +99,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374873.499999987,
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -123,6 +128,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -152,6 +158,7 @@ Array [
           },
         ],
       },
+      "first": true,
       "initial": Array [
         100,
         100,
@@ -176,6 +183,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -200,6 +208,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -224,6 +233,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -244,6 +254,7 @@ Array [
       "deltaY": 0,
       "dir": "Right",
       "event": Object {},
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -269,6 +280,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374825.199999963,
       },
+      "first": true,
       "initial": Array [
         100,
         100,
@@ -289,6 +301,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374841.3999999757,
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -309,6 +322,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374857.399999979,
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -329,6 +343,7 @@ Array [
         "preventDefault": [MockFunction],
         "timeStamp": 1374873.499999987,
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -357,6 +372,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -386,6 +402,7 @@ Array [
           },
         ],
       },
+      "first": true,
       "initial": Array [
         100,
         100,
@@ -410,6 +427,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -434,6 +452,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,
@@ -458,6 +477,7 @@ Array [
           },
         ],
       },
+      "first": false,
       "initial": Array [
         100,
         100,

--- a/src/index.js
+++ b/src/index.js
@@ -105,8 +105,8 @@ function getHandlers(set, handlerProps) {
       )
         event.preventDefault()
 
-      eventData.first = false;
-      return { ...state, eventData, swiping: true }
+      // first is now always false
+      return { ...state, eventData: { ...eventData, first: false }, swiping: true }
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ function getHandlers(set, handlerProps) {
       if (absX < props.delta && absY < props.delta && !state.swiping) return state
 
       const dir = getDirection(absX, absY, deltaX, deltaY)
-      let eventData = { ...state.eventData, event, absX, absY, deltaX, deltaY, velocity, dir }
+      const eventData = { ...state.eventData, event, absX, absY, deltaX, deltaY, velocity, dir }
 
       props.onSwiping && props.onSwiping(eventData)
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ function getHandlers(set, handlerProps) {
       return {
         ...state,
         ...initialState,
-        eventData: { initial: [...xy] },
+        eventData: { initial: [...xy], first: true },
         xy,
         start: event.timeStamp || 0
       }
@@ -86,7 +86,7 @@ function getHandlers(set, handlerProps) {
       if (absX < props.delta && absY < props.delta && !state.swiping) return state
 
       const dir = getDirection(absX, absY, deltaX, deltaY)
-      const eventData = { ...state.eventData, event, absX, absY, deltaX, deltaY, velocity, dir }
+      let eventData = { ...state.eventData, event, absX, absY, deltaX, deltaY, velocity, dir }
 
       props.onSwiping && props.onSwiping(eventData)
 
@@ -105,6 +105,7 @@ function getHandlers(set, handlerProps) {
       )
         event.preventDefault()
 
+      eventData.first = false;
       return { ...state, eventData, swiping: true }
     })
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,7 @@ export interface EventData {
   deltaY: number
   absX: number
   absY: number
+  first: boolean
   initial: Vector2
   velocity: number
   dir: 'Left' | 'Right' | 'Up' | 'Down'

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,17 +1,6 @@
 import * as React from 'react'
 import { Swipeable, SwipeableHandlers, SwipeableProps, SwipeCallback, useSwipeable } from 'react-swipeable'
 
-interface CopyOfEventData {
-  event: MouseEvent | TouchEvent
-  deltaX: number
-  deltaY: number
-  absX: number
-  absY: number
-  // initial: Vector2
-  velocity: number
-  dir: 'Left' | 'Right' | 'Up' | 'Down'
-}
-
 class SampleComponent extends React.PureComponent<SwipeableProps> {
   private readonly handleSwiped: SwipeCallback = () => {}
   private readonly handleSwipedLeft: SwipeCallback = () => {}
@@ -77,6 +66,7 @@ const handlers: SwipeableHandlers = useSwipeable({
       deltaY, // $ExpectType number
       absX, // $ExpectType number
       absY, // $ExpectType number
+      first, // $ExpectType boolean
       initial, // $ExpectType [number, number]
       velocity, // $ExpectType number
       dir, // $ExpectType "Left" | "Right" | "Up" | "Down"


### PR DESCRIPTION
Add a `first: boolean` value to `eventData`. Addition request from #160.
- `true` for the first `onSwiping` callback fired during a "swipe event"
- `false` for all callbacks after the first one

TODO:
- [x] tests
- [x] doc updates for `eventData`